### PR TITLE
On-page partials with Interchange

### DIFF
--- a/client/templates/page_child.html
+++ b/client/templates/page_child.html
@@ -12,4 +12,7 @@ emails:
   </div>
   <div fa-source media="medium" src="/templates/interchange/partial_2.html">
   </div>
+  <div fa-source media="large">
+    On-page template!
+  </div>
 </div>

--- a/js/angular/directives/interchange.js
+++ b/js/angular/directives/interchange.js
@@ -15,7 +15,7 @@ angular.module('foundation.interchange')
     replace: true,
     template: '<div></div>',
     link: function(scope, element, attrs, ctrl, transclude) {
-      var childScope, current, scenarios;
+      var childScope, current, scenarios, innerTemplates;
 
       var named_queries = {
         'default' : 'only screen',
@@ -54,51 +54,74 @@ angular.module('foundation.interchange')
         return matches;
       };
 
-      var collectScenarios = function(parentElement) {
+      var collectInformation = function(parentElement) {
         scenarios = [];
+        innerTemplates = [];
         var elements = parentElement.children();
         var i = 0;
 
         angular.forEach(elements, function(el) {
           var elem = angular.element(el);
-          scenarios[i] = { media: elem.attr('media'), src: elem.attr('src') };
+
+          //save on-page templates
+          if (!elem.attr('src')) {
+            innerTemplates[i] = el;
+            scenarios[i] = { media: elem.attr('media'), templ: i };
+          } else {
+            scenarios[i] = { media: elem.attr('media'), src: elem.attr('src') };
+          }
+
           i++;
         });
 
       };
 
+      var checkScenario = function(scenario) {
+        return !current || (scenario.src !== current.src) || (scenario.templ && scenario.templ !== current.templ);
+      };
+
+
       //setup
       foundationApi.subscribe('resize', function(msg) {
         transclude(function(clone, newScope) {
-          if(!scope.scenarios) {
-            collectScenarios(clone);
+          if(!scope.scenarios || !scope.innerTemplates) {
+            collectInformation(clone);
           }
           var ruleMatches = matched();
           var scenario = scenarios[ruleMatches[0].ind];
 
-          if(current && scenario.src == current.src) {
-          } else {
+          if(checkScenario(scenario)) {
             var compiled;
-            var loader = templateLoader(scenario.src);
 
             if(childScope) {
               childScope.$destroy();
               childScope = null;
             }
 
-            loader.success(function(html) {
+            if(scenario.templ) {
+              //on page template logic
               childScope = newScope;
-              element.html(html);
-              //compiled = $compile(html)(childScope);
-            }).then(function(){
+              element.html(innerTemplates[scenario.templ]);
               $compile(element.contents())(childScope);
               current = scenario;
-            });
+            } else {
+              //dynamic partial
+              var loader = templateLoader(scenario.src);
+              loader.success(function(html) {
+                childScope = newScope;
+                element.html(html);
+                //compiled = $compile(html)(childScope);
+              }).then(function(){
+                $compile(element.contents())(childScope);
+                current = scenario;
+              });
+            }
           }
         });
 
       });
 
+      //init
       foundationApi.publish('resize', 'initial resize');
 
     }


### PR DESCRIPTION
So interchange currently works by requiring separate partials with content like so:

``` html
<div fa-interchange>
   <div fa-source media="small" src="/path/to/template.html"></div>
</div>
```

This allows for on-page partials like so:

``` html
<div fa-interchange>
   <div fa-source media="small" src="/path/to/template"></div>
   <div fa-source media="medium"> Here is my new on-page partial!</div>
</div>
```
