### PR TITLE
Removing quotes from @each arguments

### DIFF
--- a/scss/components/_utilities.scss
+++ b/scss/components/_utilities.scss
@@ -15,9 +15,9 @@
   Vertical alignment
 */
 .v-align {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 
   $align-values: (
     'top': flex-start,
@@ -25,13 +25,13 @@
     'bottom': flex-end,
   );
 
-  @each $orient in ('top', 'center', 'bottom') {
+  @each $orient in (top, center, bottom) {
     .align-#{$orient} {
       align-self: map-get($align-values, $orient);
     }
   }
   @each $size in $breakpoint-classes {
-    @each $orient in ('top', 'center', 'bottom') {
+    @each $orient in (top, center, bottom) {
       @include breakpoint($size) {
         .#{$size}-align-#{$orient} {
           align-self: map-get($align-values, $orient);
@@ -65,7 +65,7 @@
     }
   }
 }
-@each $orientation in ('portrait', 'landscape') {
+@each $orientation in (portrait, landscape) {
   @include breakpoint($orientation) {
     .hide-for-#{$orientation} {
       display: none;
@@ -79,7 +79,7 @@
 /*
   Text alignment
 */
-@each $align in ('left', 'right', 'center', 'justify') {
+@each $align in (left, right, center, justify) {
   @each $size in $breakpoint-classes {
     .text-#{$align} {
       text-align: $align;
@@ -101,7 +101,7 @@
   Floating
 */
 .clearfix { @include clearfix; }
-@each $float in ('left', 'right', 'none') {
+@each $float in (left, right, none) {
   .float-#{$float} {
     float: #{$float};
   }


### PR DESCRIPTION
Quoted arguments passed to `@each in` are not handled as you might expect in Sass. Instead, the values should be passed in without quotes.

Before

``` scss
@each $align in ('left', 'right', 'center', 'justify') {
  .text-#{$align} {
    text-align: $align;
  }
}

// Output CSS Looks like this
.text-center {
  text-align: "center";
}
```

After

``` scss
@each $align in (left, right, center, justify) {
  .text-#{$align} {
    text-align: $align;
  }
}

// Output CSS Looks like this
.text-center {
  text-align: center;
}
```

Let me know if you'd like to handle this some other way. I haven't tested against multiple versions of Sass, but I'm on `Sass 3.4.6`.
