### PR TITLE
Gulp directory issue

### DIFF
--- a/bin/gulp-dynamic-routing.js
+++ b/bin/gulp-dynamic-routing.js
@@ -7,6 +7,7 @@ var fs           = require('fs');
 
 module.exports = function(options) {
   var configs = [];
+  var directory = process.cwd();
 
   function bufferContents(file, enc, cb) {
     var config;
@@ -24,7 +25,7 @@ module.exports = function(options) {
       if(content.attributes.name) {
         file.contents = new Buffer(content.body);
         config = content.attributes;
-        var relativePath = path.relative(__dirname + path.sep + '..' + path.sep + options.root, file.path);
+        var relativePath = path.relative(directory + path.sep + options.root, file.path);
         config.path = '/' + relativePath.split(path.sep).join('/');
         configs.push(config);
       }


### PR DESCRIPTION
So, it turns out it's pretty difficult to figure out how and where a module has been initiated from. Luckily, this is gulp and most likely anyone running Gulp will be running it at the root of their application. So process.cwd() should give us the right directory.

If it keeps failing for people, there's also [callsite](https://www.npmjs.org/package/callsite) package to crawl up a stack to find the right file that initiated the gulp module. If that still fails, we'll need to add a permanent requirement of adding `{ directory: __dirname}` as part of the module declaration.
