### PR TITLE
Moving scope.apply in the tabs

### DIFF
--- a/js/angular/directives/tabs.js
+++ b/js/angular/directives/tabs.js
@@ -19,7 +19,6 @@ angular.module('foundation.tabs')
         }
       });
 
-      $scope.$apply();
     };
 
     controller.addTab = function addTab(tabScope) {
@@ -163,6 +162,7 @@ angular.module('foundation.tabs')
 
         foundationApi.subscribe(tab.scope.id, function(msg) {
           foundationApi.publish(tab.parentContent, ['activate', tab.scope.id]);
+          scope.$apply();
         });
 
       }


### PR DESCRIPTION
Fixing #126 

The scope.apply was required to force Angular to update the DOM after an external FoundationApi trigger for a tab.
