### PR TITLE
Iconic integration with components

### DIFF
--- a/docs/templates/iconic.html
+++ b/docs/templates/iconic.html
@@ -8,6 +8,101 @@ url: /iconic
 
 ---
 
+<a href="#" class="large button">
+  <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+  Search
+</a>
+<a href="#" class="large alert button">
+  <img zf-iconic data-src="/assets/img/iconic/ban.svg">
+  Delete
+</a>
+<a href="#" class="large success button">
+  <img zf-iconic data-src="/assets/img/iconic/circle-check.svg">
+  Save
+</a>
+<a href="#" class="large secondary button">
+  <img zf-iconic data-src="/assets/img/iconic/cart.svg">
+  Add to Cart
+</a>
+
+---
+
+<ul class="button-group">
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li class="secondary"><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Sleep
+  </a></li>
+</ul>
+
+<ul class="expanded segmented button-group">
+  <li class="is-active"><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Sleep
+  </a></li>
+</ul>
+
+---
+
+<ul class="menu-bar icon-left">
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+</ul>
+
+<ul class="primary menu-bar icon-top">
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+  <li><a href="#">
+    <img zf-iconic data-src="/assets/img/iconic/magnifying-glass.svg">
+    Eat
+  </a></li>
+</ul>
+
+---
+
+<div class="title-bar">
+  <div class="left">
+    <a href="#">
+      <img zf-iconic data-src="/assets/img/iconic/account.svg">
+      Buy
+    </a>
+  </div>
+</div>
+
+<div class="dark title-bar">
+  <div class="center">
+    <a href="#">
+      <img zf-iconic data-src="/assets/img/iconic/account.svg">
+      Buy
+    </a>
+  </div>
+</div>
+
+---
+
 <img zf-iconic data-src="/assets/img/iconic/account.svg" class="iconic-lg">
 <img zf-iconic data-src="/assets/img/iconic/action.svg" class="iconic-lg">
 <img zf-iconic data-src="/assets/img/iconic/ban.svg" class="iconic-lg">

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -27,6 +27,16 @@ $btngroup-radius: $button-radius !default;
       border-right: 1px solid scale-color($btngroup-background, $lightness: -25%);
     }
   }
+
+  @if using(iconic) {
+    .iconic {
+      width: 1em;
+      height: 1em;
+      vertical-align: middle;
+      margin-right: 0.25em;
+      margin-top: -2px; // The icons are oddly misaligned
+    }
+  }
 }
 
 %button-group-segmented {
@@ -100,6 +110,10 @@ $btngroup-radius: $button-radius !default;
           background: $hover-color;
           color: $background;
         }
+
+        @if using(iconic) {
+          .iconic { @include color-icon($background); }
+        }
       }
 
       // This is the button when it's active
@@ -107,7 +121,11 @@ $btngroup-radius: $button-radius !default;
       > input:checked + label {
         &, &:hover {
           background: $background;
-          color: if(lightness($background) > 60%, #000, #fff);
+          color: isitlight($background);
+        }
+
+        @if using(iconic) {
+          .iconic { @include color-icon(isitlight($background)); }
         }
       }
     }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -23,6 +23,7 @@ $button-tag-selector: true !default;
   -webkit-appearance: none;
   -webkit-font-smoothing: antialiased;
   transition: background 0.25s ease-out;
+  vertical-align: middle;
 
   padding: $button-padding;
   margin: $button-margin;
@@ -56,6 +57,16 @@ $button-tag-selector: true !default;
 
   @if $expand {
     @include button-expand;
+  }
+
+  @if using(iconic) {
+    .iconic {
+      width: 1em;
+      height: 1em;
+      vertical-align: middle;
+      margin-right: 0.25em;
+      margin-top: -2px; // The icons are oddly misaligned
+    }
   }
 }
 @mixin button-expand($expand: true) {
@@ -111,6 +122,22 @@ $button-tag-selector: true !default;
     border-color: $background;
     &:hover {
       border-color: scale-color($background, $lightness: -25%);
+    }
+  }
+
+  @if using(iconic) {
+    @if $style == hollow {
+      .iconic {
+        @include color-icon($background);
+      }
+      &:hover .iconic {
+        @include color-icon(scale-color($background, $lightness: 25%));
+      }
+    }
+    @else {
+      .iconic {
+        @include color-icon($color);
+      }
     }
   }
 }

--- a/scss/components/_iconic.scss
+++ b/scss/components/_iconic.scss
@@ -59,6 +59,18 @@ $iconic-accent-stroke: $iconic-accent-fill;
 }
 
 @include exports(iconic) {
+  .iconic {
+    width: 1rem;
+    height: 1rem;
+    vertical-align: middle;
+
+    a > & {
+      @include color-icon($primary-color);
+      margin-top: -2px;
+      margin-right: 0.25rem;
+    }
+  }
+
   .iconic * {
     fill: $iconic-primary-fill;
     stroke: $iconic-primary-stroke;

--- a/scss/components/_menu-bar.scss
+++ b/scss/components/_menu-bar.scss
@@ -114,15 +114,21 @@ $menubar-icon-spacing: $menubar-item-padding !default;
     background: $background-active;
     color: $color-active
   }
+
+  // Iconic
+  @if using(iconic) {
+    .iconic { @include color-icon($color); }
+  }
 }
 
 @mixin menu-bar-icons(
   $position: left,
-  $size: $menubar-icon-size
+  $size: $menubar-icon-size,
+  $color: null
 ) {
   li {
     // Sizing
-    img {
+    img, .iconic {
       margin: 0;
       @if $menubar-icon-size != false {
         width: $menubar-icon-size;
@@ -135,30 +141,30 @@ $menubar-icon-spacing: $menubar-item-padding !default;
       a {
         flex-flow: row nowrap;
         align-items: center;
-        img { margin-right: $menubar-icon-spacing; }
+        img, .iconic { margin-right: $menubar-icon-spacing; }
       }
     }
     @else {
       a {
-        img { margin-right: 0; }
+        img, .iconic { margin-right: 0; }
       }
     }
     @if $position == top {
       a {
         flex-flow: column nowrap;
-        img { margin-bottom: $menubar-icon-spacing; }
+        img, .iconic { margin-bottom: $menubar-icon-spacing; }
       }
     }
     @if $position == right {
       a {
         flex-flow: row-reverse nowrap;
-        img { margin-left: $menubar-icon-spacing; }
+        img, .iconic { margin-left: $menubar-icon-spacing; }
       }
     }
     @if $position == bottom {
       a {
         flex-flow: column-reverse nowrap;
-        img { margin-top: $menubar-icon-spacing; }
+        img, .iconic { margin-top: $menubar-icon-spacing; }
       }
     }
   }

--- a/scss/components/_title-bar.scss
+++ b/scss/components/_title-bar.scss
@@ -116,10 +116,12 @@ $titlebar-item-classes: (
     &.primary {
       @include title-bar-style($primary-color, isitlight($primary-color));
       a, a:hover { color: isitlight($primary-color); }
+      @if using(iconic) { .iconic { @include color-icon(isitlight($primary-color)); } }
     }
     &.dark {
       @include title-bar-style($dark-color, #fff);
       a, a:hover { color: #fff; }
+      @if using(iconic) { .iconic { @include color-icon(#fff); } }
     }
   }
     .title-bar-bottom {

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -26,16 +26,16 @@ $foundation-version: '0.0.1';
 
 // Components
 @import
-	"components/action-sheet",
+  "components/iconic",
+  "components/action-sheet",
   "components/block-list",
   "components/button",
   "components/button-group",
-	"components/cards",
+  "components/cards",
   "components/extras",
-	"components/forms",
-	"components/grid",
-	"components/title-bar",
-  "components/iconic",
+  "components/forms",
+  "components/grid",
+  "components/title-bar",
   "components/label",
   "components/lists",
 	"components/menu-bar",

--- a/scss/helpers/_functions.scss
+++ b/scss/helpers/_functions.scss
@@ -3,6 +3,20 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
+// [PH] Using
+@function using($name) {
+  // Import from global scope
+  $include-css: $include-css !global;
+  $module-key: map-get($include-css, $name);
+
+  @if $module-key == true or $module-key == null {
+    @return true;
+  }
+  @else {
+    @return false;
+  }
+}
+
 /**
  *   Exports
  *   Outputs the chunk of content passed if component $name hasn't yet been output.


### PR DESCRIPTION
Some components will automatically color Iconic icons inside of them, based on how mixins are used or the coloring class of the parent.

**Components:**
- [x] Button
- [x] Button group
- [x] Menu bar
- [ ] Notification
- [x] Title bar

Notifications are weird because the directive is hardcoded to just take a `src` attribute of an image and stick it in there, which means it can't compile a `zf-iconic` directive in the process. We'll have to look into that.
