### PR TITLE
Remove local server address escaping in docs. Closes ##207

### DIFF
--- a/docs/templates/install-update.html
+++ b/docs/templates/install-update.html
@@ -68,7 +68,7 @@ foundation-apps start
 
 This will assemble all of the pieces&mdash;the Angular components, Sass, and views&mdash;into a new folder called <code>build</code>, which is your final app. The build process will also setup a temporary server that points to the finished app. You can get to the server by going to this URL in your browser:
 
-<hljs language="bash">
+<hljs language="bash" no-escape>
 http://localhost:8080
 </hljs>
 


### PR DESCRIPTION
This is trivial change It ensures hljs directive does not escape localhost address so it renders
address exactly as in `README.md`.

After adding 'no-escape` attribute markup will be rendered as:

``` html
<code class="hljs groovy bash">http://localhost:<span class="hljs-number">8080</span>
</code>
```
