### PR TITLE
Corrected an error in Accordion docs

### DIFF
--- a/docs/templates/accordion.html
+++ b/docs/templates/accordion.html
@@ -31,20 +31,20 @@ title: Accordion
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
 <hljs>
-  <zf-accordion-set>
-    <zf-accordion
+  <zf-accordion>
+    <zf-accordion-item
       title="Input your title here">
       Content goes here
-    </zf-accordion>
-      <zf-accordion
+    </zf-accordion-item>
+      <zf-accordion-item
       title="Input your title here">
       Content goes here
-    </zf-accordion>
-      <zf-accordion
+    </zf-accordion-item>
+      <zf-accordion-item
       title="Input your title here">
       Content goes here
-    </zf-accordion>
-  </zf-accordion-set>
+    </zf-accordion-item>
+  </zf-accordion>
 </hljs>
   </div>
   <div class="small-12 medium-6 grid-content">


### PR DESCRIPTION
As we discussed in https://github.com/zurb/foundation-apps/issues/143, accordion and accordion-item should be the angular directive names.

But, old notation (accordion-set and accordion) is used at one instance in docs.
This pull request fixes it 
