### PR TITLE
grid-orient uses vertical/horizontal alignment parameters not true/false

### DIFF
--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -49,12 +49,12 @@ $block-grid-max-size: 6;
 
   @group grid
 
-  @param {string} $direction - Direction of the grid, either horizontal or vertical.
+  @param {string} $orientation - Direction of the grid, either horizontal or vertical.
 
   @output A flex-flow property to match the direction given.
 */
-@mixin grid-orient($direction: horizontal) {
-	@if ($direction == vertical) {
+@mixin grid-orient($orientation: horizontal) {
+	@if ($orientation == vertical) {
 		flex-flow: column nowrap;
 		align-items: stretch;
 	}
@@ -210,14 +210,14 @@ $block-grid-max-size: 6;
 /*
 	Frames are containers that stretch to the full dimmensions of the browser window.
 */
-@mixin grid-frame($size: expand, $direction: horizontal, $wrap: false, $align: left, $order: 0) {
+@mixin grid-frame($size: expand, $orientation: horizontal, $wrap: false, $align: left, $order: 0) {
 	display: flex;
 	height: 100vh;
 	position: relative;
 	overflow: hidden;
 
 	@include grid-size($size);
-  @include grid-orient($direction);
+  @include grid-orient($orientation);
 	@include grid-wrap($wrap);
 	@include grid-align($align);
 	@include grid-order($order);
@@ -226,14 +226,14 @@ $block-grid-max-size: 6;
 /*
 	Groups are collections of content items. They're the "rows" of Foundation for Apps.
 */
-@mixin grid-block($size: expand, $direction: horizontal, $wrap: false, $align: left, $order: 0) {
-	@include grid-frame($size, $direction, $wrap, $align, $order);
+@mixin grid-block($size: expand, $orientation: horizontal, $wrap: false, $align: left, $order: 0) {
+	@include grid-frame($size, $orientation, $wrap, $align, $order);
 
 	// Reset the height used by frames
 	height: auto;
 
 	// Blocks will scroll by default if their content overflows
-	@if ($direction == vertical) {
+	@if ($orientation == vertical) {
 		overflow-x: auto;
 	}
 	@else {


### PR DESCRIPTION
Since grid-orient uses vertical or horizontal to detect what to do you can't pass true/false and get vertical alignment.  Another option would be to change the acceptable values for the parameter to grid-frame and grid-block
