### PR TITLE
Remove duplicate entry of release version in changelog

### DIFF
--- a/docs/templates/changelog.html
+++ b/docs/templates/changelog.html
@@ -72,61 +72,6 @@ title: Changelog
 
 <hr>
 
-<h3>Version 1.0.0 — Matterhorn</h3>
-
-<p>Welcome to Foundation for Apps 1.0.0! Thanks for swinging by to try it out.</p>
-
-<p>Our initial release of the framework includes:</p>
-
-<p><strong>An awesome, responsive flexbox-based grid</strong> for creating robust, responsive app layouts.</p>
-
-<p><strong>The Motion UI library</strong> for easily animating pages and components. You can also use our mixins to write custom animations.</p>
-
-<p><strong>Our Gulp-powered Angular helpers</strong> which allow you to harness the power of the Angular UI Router library without writing any JavaScript.</p>
-
-<p>The framework also includes these sweet components:</p>
-<ul>
- <li>Block list</li>
- <li>Button</li>
- <li>Button group</li>
- <li>Card</li>
- <li>Forms</li>
- <li>Label and badge</li>
- <li>Menu bar</li>
- <li>Switch</li>
- <li>Title bar</li>
- <li>Typography</li>
- <li>Visibility and utility classes</li>
-</ul>
-
-<p>These components are also available as Angular directives:</p>
-<ul>
- <li>Accordion</li>
- <li>Action sheet</li>
- <li>Modal</li>
- <li>Notification</li>
- <li>Off-canvas</li>
- <li>Panel</li>
- <li>Popup</li>
- <li>Tabs</li>
-</ul>
-
-<h4>How to Contribute</h4>
-
-<p>We love feedback! Help us find bugs and suggest improvements or new features. Follow us on Twitter at [@ZURBFoundation](https://twitter.com/zurbfoundation) to keep up-to-date with what's new, or to just shoot the breeze.</p>
-
-<p>If you find a problem or have an idea, open a [new issue](https://github.com/zurb/foundation-apps/issues) on GitHub. When filing a bug report, make sure you specify the browser and operating system you're on, and toss us a screenshot or show us how we can recreate the issue.</p>
-
-<h4>Known Issues</h4>
-
-<ul>
- <li>Some issues with the flexbox grid in IE10</li>
- <li>Mobile Safari doesn't place fixed-position elements (modals, notifications) at the </li>right z-index — #190
- <li>Range sliders aren't properly styled in IE10+ — #191</li>
-</ul>
-
-<hr>
-
 <h3>Version 1.0.0 RC1 — Mont Blanc</h3>
 
 <p>It's our 1.0 release candidate! Thanks for stopping by to take a look.</p>


### PR DESCRIPTION
1.0.0 Matterhorn is in the documentation twice.
