### PR TITLE
Prevent content (footer) from flashing before template loads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
         <!-- /Sidebar nav -->
 
         <!-- Main content -->
-        <div class="medium-9 large-10 grid-content">
+        <div class="medium-9 large-10 grid-content" ng-show="$state.current.name.length">
           <div class="grid-container main-docs-section">
             <a class="small secondary expand button hide-for-medium" zf-toggle="sidebar">Show Components</a>
             <div ng-class="['ui-animation']" ui-view autoscroll='true'></div>


### PR DESCRIPTION
This is a quick fix for the most immediate bug I found when visiting http://foundation.zurb.com/apps/docs - the footer flashes for a quick second before the content loads - very jarring.

The **real** fix involves allowing the parent `ui-view` in the docs to contain named child views like `ui-view="content"` and `ui-view="footer"`, which is possible with the way Foundation handles dynamic routes via UI-Router (I'm pretty sure), but might require a bigger effort to move some parts around in the documentation.

For now, this is a minimally viable fix that does the job.
