### PR TITLE
Fixed syntax highlighting issue in modal docs

### DIFF
--- a/docs/templates/modal.html
+++ b/docs/templates/modal.html
@@ -16,7 +16,7 @@ title: Modal
 <p>You can create a Modal with this basic HTML</p>
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
-<hljs>
+<hljs language="html">
 <a href="#" zf-open="basicModal">Open modal</a>
 
 <zf-modal id="basicModal" overlay="true">
@@ -40,7 +40,7 @@ title: Modal
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
 
-<hljs>
+<hljs language="html">
 <a class="button" href="#" zf-open="advancedModal">Open modal</a>
 <zf-modal class="small" id="advancedModal" overlay="false">
   <a href="#" zf-close>&times;</a>


### PR DESCRIPTION
Syntax highlighting of advanced code snippet of modal  is not correct.
http://foundation.zurb.com/apps/docs/#!/modal

Due to angular directives, highlight.js couldn't detect language of few code snippets.
In this pull request, I fixed this issue in modal docs by explicitly specifying language="html"
