### PR TITLE
Made accordion-title-background-active value relative to accordion-title-background

### DIFF
--- a/docs/templates/accordion.html
+++ b/docs/templates/accordion.html
@@ -140,7 +140,7 @@ $accordion-border: 1px solid $gray-dark;
 
 $accordion-title-background: $gray-light;
 $accordion-title-background-hover: smartscale($accordion-title-background, 5%);
-$accordion-title-background-active: lighten($gray-light, 2);
+$accordion-title-background-active: smartscale($accordion-title-background, 3%);
 $accordion-title-color: isitlight($accordion-title-background);
 $accordion-title-color-active: isitlight($accordion-title-background);
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -244,7 +244,7 @@ $include-css: (
 
 // $accordion-title-background: $gray-light;
 // $accordion-title-background-hover: smartscale($accordion-title-background, 5%);
-// $accordion-title-background-active: lighten($gray-light, 2);
+// $accordion-title-background-active: smartscale($accordion-title-background, 3%);
 // $accordion-title-color: isitlight($accordion-title-background);
 // $accordion-title-color-active: isitlight($accordion-title-background);
 

--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -9,7 +9,7 @@ $accordion-border: 1px solid $gray-dark !default;
 
 $accordion-title-background: $gray-light !default;
 $accordion-title-background-hover: smartscale($accordion-title-background, 5%) !default;
-$accordion-title-background-active: lighten($gray-light, 2) !default;
+$accordion-title-background-active: smartscale($accordion-title-background, 3%) !default;
 $accordion-title-color: isitlight($accordion-title-background) !default;
 $accordion-title-color-active: isitlight($accordion-title-background) !default;
 


### PR DESCRIPTION
Fixed issue https://github.com/zurb/foundation-apps/issues/243
Changed from

``` scss
$accordion-title-background-active: lighten($gray-light, 2) !default;
```

to

``` scss
$accordion-title-background-active: smartscale($accordion-title-background, 3%);
```

I referred to foundation for sites codebase  and used smartscaling of 3% for active state.
This creates distinction between between hover (5%) and active (3%) states
