### PR TITLE
Fixed misspelled words in docs

### DIFF
--- a/docs/templates/angular.html
+++ b/docs/templates/angular.html
@@ -47,12 +47,12 @@ url: /mail
 <hljs>
 <!-- Basic UI View -->
 <div ui-view>
-          
+
 </div>
 
 <!-- Or add Ui View to our existing grid classes -->
 <div ui-view class="grid-block small-12">
-          
+
 </div>
 
 <!-- Or to animate your views you can add the ng-class of ui-animation -->
@@ -99,7 +99,7 @@ url: /inbox
 <hr>
 
 <h3>Controllers</h3>
-<p>Angular supports this neat thing called controllers. They can get confusing and so each template gets its own <code>DefaultController</code> which can be overriden like so:</p>
+<p>Angular supports this neat thing called controllers. They can get confusing and so each template gets its own <code>DefaultController</code> which can be overridden like so:</p>
 
 <hljs>
 controller: MyController

--- a/docs/templates/block-lists.html
+++ b/docs/templates/block-lists.html
@@ -5,7 +5,7 @@ title: Block List
 ---
 
 <h2> Block List</h2>
-<h3 class="subheader">A useful list component that can accomodate a variety of styles and controls.</h3>
+<h3 class="subheader">A useful list component that can accommodate a variety of styles and controls.</h3>
 
 <hr />
 
@@ -216,7 +216,7 @@ title: Block List
     $color: #000, // Foreground color
     $background, #fff, // Background color
     $background-hover: #fff, // Background color of elements on hover
-    $padding: 1rem, // 
+    $padding: 1rem, //
   );
 
   // This adds support for icons

--- a/docs/templates/button.html
+++ b/docs/templates/button.html
@@ -159,7 +159,7 @@ title: Button
 </div>
 
 <h3>Button Group Segmented</h3>
-<p>Button groups can have a segemented look with an active class applied.</p>
+<p>Button groups can have a segmented look with an active class applied.</p>
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
 <hljs>

--- a/docs/templates/forms.html
+++ b/docs/templates/forms.html
@@ -5,7 +5,7 @@ title: Forms
 ---
 
 <h2>Forms</h2>
-<h3 class="subheader">Easily create powerful and versatile form layouts with our built in form styles and the Foundation grid. We also included some handy form controlls to make your app more complete.</h3>
+<h3 class="subheader">Easily create powerful and versatile form layouts with our built in form styles and the Foundation grid. We also included some handy form controls to make your app more complete.</h3>
 
 <hr>
 
@@ -27,7 +27,7 @@ title: Forms
         <label>Separate Label</label>
         <select name="" id="">
           <option value="">Breakfast</option>
-          <option value="">Bacon Panckakes</option>
+          <option value="">Bacon Pancakes</option>
           <option value="">Mountain Dew</option>
         </select>
       </div>
@@ -80,7 +80,7 @@ title: Forms
 <div class="grid-block">
   <div class="small-12 grid-content">
 <hljs>
-<form>  
+<form>
   <label>
     Input Label
     <input type="text" placeholder="Text field">
@@ -96,7 +96,7 @@ title: Forms
       <label>Separate Label</label>
       <select name="" id="">
         <option value="">Breakfast</option>
-        <option value="">Bacon Panckakes</option>
+        <option value="">Bacon Pancakes</option>
         <option value="">Mountain Dew</option>
       </select>
     </div>
@@ -125,8 +125,8 @@ title: Forms
   </div>
 </form>
 </hljs>
-    
-    <form>  
+
+    <form>
       <label>
         Input Label
         <input type="text" placeholder="Text field">
@@ -142,7 +142,7 @@ title: Forms
           <label>Select Label</label>
           <select name="" id="">
             <option value="">Breakfast</option>
-            <option value="">Bacon Panckakes</option>
+            <option value="">Bacon Pancakes</option>
             <option value="">Mountain Dew</option>
           </select>
         </div>
@@ -229,7 +229,7 @@ title: Forms
 <hr>
 
 <h3>Switch</h3>
-<p>Switches are toggle element that switch between an Off and On state on tap or click. They make use of checkbox inputs (or radio buttons) and require no javascript.</p>
+<p>Switches are toggle element that switch between an Off and On state on tap or click. They make use of checkbox inputs (or radio buttons) and require no JavaScript.</p>
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
 <hljs>

--- a/docs/templates/install-update.html
+++ b/docs/templates/install-update.html
@@ -11,7 +11,7 @@ title: Install
 
 <h3>Quick Install: Using our CLI</h3>
 
-<p>Just like with Foundation for Sites, we wrote an awesome command-line tool to make settting up new Foundation for Apps projects a breeze. The CLI downloads a template project that uses Foundation, Angular, Sass, and Gulp. If you'd rather install our components into your own stack, see our advanced instructions below.</p>
+<p>Just like with Foundation for Sites, we wrote an awesome command-line tool to make setting up new Foundation for Apps projects a breeze. The CLI downloads a template project that uses Foundation, Angular, Sass, and Gulp. If you'd rather install our components into your own stack, see our advanced instructions below.</p>
 
 <div class="grid-block">
   <div class="small-12 medium-4 grid-content">

--- a/docs/templates/motion-ui.html
+++ b/docs/templates/motion-ui.html
@@ -241,7 +241,7 @@ $motion-spin-and-fade: true;
 
 // Default speed for transitions and animations
 $motion-duration-default: 700ms;
-// Slow and fast modifiders
+// Slow and fast modifiers
 $motion-duration-slow: 1.4s;
 $motion-duration-fast: 300ms;
 

--- a/docs/templates/notification.html
+++ b/docs/templates/notification.html
@@ -5,7 +5,7 @@ title: Notification
 ---
 
 <h2>Notification</h2>
-<h3 class="subheader">An alert that pins to the corner of the screen when triggered by JavaScript. It can be set to disappear after a certain period of time, or to stay put until the user clicks on it. A custom action can be asigned to a notification as well.</h3>
+<h3 class="subheader">An alert that pins to the corner of the screen when triggered by JavaScript. It can be set to disappear after a certain period of time, or to stay put until the user clicks on it. A custom action can be assigned to a notification as well.</h3>
 
 <h3 class="subheader">Optionally, the notifications directive can also tap into the browser's native notification support, if it exists.</h3>
 

--- a/docs/templates/panel.html
+++ b/docs/templates/panel.html
@@ -36,7 +36,7 @@ title: Panel
 <div zf-panel id="example-panel-1" position="right">
   <a href="#" zf-close class="close-button">&times;</a>
   <p>Basic Panel</p>
-</div zf-panel>
+</div>
 
 <!-- Fixed example -->
 <div zf-panel id="panel-fixed" position="right">


### PR DESCRIPTION
Fixed all misspelled words I could find.
Some instance where trailing white space was removed
1 instance of closing div tag that needed fixed
