### PR TITLE
Add element type to actionsheet directive

### DIFF
--- a/js/angular/directives/actionsheet.js
+++ b/js/angular/directives/actionsheet.js
@@ -25,7 +25,7 @@ angular.module('foundation.actionsheet')
 angular.module('foundation.actionsheet')
   .directive('zfActionSheet', ['FoundationApi', function(foundationApi) {
   return {
-    restrict: 'A',
+    restrict: 'EA',
     transclude: true,
     replace: true,
     templateUrl: 'partials/actionsheet.html',


### PR DESCRIPTION
In aditional options example in [docs](http://foundation.zurb.com/apps/docs/#!/action-sheet)
zf-action-sheet directive is used as an element.

But element type is not added to restrict options of directive.
Fixing this.
