### PR TITLE
Fixed Nav's Broken Docs Link in Documenation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
               <a href="http://foundation.zurb.com/apps/support.html">Support</a>
             </li>
             <li>
-              <a class="current" href="docs.html">Docs</a>
+              <a class="current" href="#">Docs</a>
             </li>
             <li><a href="http://foundation.zurb.com/apps/getting-started.html">Getting Started</a></li>
           </ul>


### PR DESCRIPTION
The top nav bar had a broken link for "Docs" that would lead either to http://localhost:8080/docs.html on a local installation or http://foundation.zurb.com/apps/docs/docs.html on the actual Foundation for Apps website Documentation. Changed to a null link (#).
