### PR TITLE
Removed unnecessary click handler from actionsheet button partial

### DIFF
--- a/js/angular/partials/actionsheet-button.html
+++ b/js/angular/partials/actionsheet-button.html
@@ -1,7 +1,6 @@
 <div>
   <a href="#"
     class="button"
-    ng-click="toggle()"
     ng-if="title.length > 0">{{ title }}</a>
   <div ng-transclude></div>
 </div>


### PR DESCRIPTION
A click handler is defined in the link phase of actionsheet-button to catch clicks on both default button and custom button.

Unnecessary click handler is defined on the default button of actionsheet-button partial.
Removing it in this pull request.
