### PR TITLE
Fixed syntax detection of code snippets by configuring highlight.js

### DIFF
--- a/docs/assets/js/angular.js
+++ b/docs/assets/js/angular.js
@@ -20,7 +20,7 @@ angular.module('application', [
     'foundation.tabs',
     'foundation.iconic'
   ])
-    .config(['$FoundationStateProvider', '$urlRouterProvider', '$locationProvider', function(FoundationStateProvider, $urlProvider, $locationProvider) {
+    .config(['$FoundationStateProvider', '$urlRouterProvider', '$locationProvider', 'hljsServiceProvider', function(FoundationStateProvider, $urlProvider, $locationProvider, hljsServiceProvider) {
 
     $urlProvider.otherwise('/');
 
@@ -32,6 +32,10 @@ angular.module('application', [
     });
 
     $locationProvider.hashPrefix('!');
+
+    hljsServiceProvider.setOptions({
+      languages: ['bash', 'html', 'js', 'sass', 'scss']
+    });
 }])
   .run(['FoundationInit', '$rootScope', '$state', '$stateParams', function(foundationInit, $rootScope, $state, $stateParams) {
     foundationInit.init();


### PR DESCRIPTION
Syntax detection of code snippets is failing in few instances of docs
For example in [tabs docs](http://foundation.zurb.com/apps/docs/#!/tabs),
syntax of html snippets is detected as applescript, syntax of sass mixins snippets is detected is less.

This issue can be prevented by configuring highlight.js with known set of languages for which syntax highlighting is required. This helps highlight.js to detect syntax from one of given languages.

In this pull request, I configured highlight.js to limit syntax detection to one of these languages  ['bash',  'html', 'js', 'sass', 'sccs']
