### PR TITLE
Add option to specify a custom active class

### DIFF
--- a/scss/components/_menu-bar.scss
+++ b/scss/components/_menu-bar.scss
@@ -18,6 +18,7 @@ $menubar-background-active: $menubar-background-hover;
 $menubar-color: isitlight($menubar-background) !default;
 $menubar-color-hover: $menubar-color !default;
 $menubar-color-active: $menubar-color-hover;
+$menubar-active-class: "is-active" !default;
 
 $menubar-item-padding: $global-padding !default;
 $menubar-icon-size: 25px !default;
@@ -111,7 +112,7 @@ $menubar-icon-spacing: $menubar-item-padding !default;
       color: $color-hover;
     }
   }
-  .is-active > a {
+  .#{$menubar-active-class} > a {
     background: $background-active;
     color: $color-active
   }


### PR DESCRIPTION
By default the active menu bar selector is .is-active, this setting lets you customise this class. (some frameworks have .active as selector class).
