### PR TITLE
Fix bug when including xxlarge in $breakpoint-classes

### DIFF
--- a/scss/helpers/_breakpoints.scss
+++ b/scss/helpers/_breakpoints.scss
@@ -59,7 +59,13 @@ $breakpoint-classes: (small medium large) !default;
     @if type-of($bp) == 'string' {
       @if map-has-key($breakpoints, $bp) {
         @if $dir == 'only' {
-          $bpMax: map-next($breakpoints, $bp) - (1/16);
+          $next-bp: map-next($breakpoints, $bp);
+          @if $next-bp == null {
+            $bpMax: null;
+          }
+          @else {
+            $bpMax: $next-bp - (1/16);
+          }
         }
         $bp: map-get($breakpoints, $bp);
         $named: true;
@@ -81,7 +87,10 @@ $breakpoint-classes: (small medium large) !default;
       // And lo, a media query was born
       @if $dir == 'only' {
         @if $named == true {
-          $str: $str + ' and (min-width: #{$bp}) and (max-width: #{$bpMax})';
+          $str: $str + ' and (min-width: #{$bp})';
+          @if $bpMax != null {
+            $str: $str + ' and (max-width: #{$bpMax})';
+          }
         }
         @else {
           @debug 'ERROR: Only named media queries can have an "only" range.';


### PR DESCRIPTION
When setting `$breakpoint-classes: (small medium large xlarge xxlarge)` compiling fails, because xxlarge is the last item in the $breakpoints array. The breakpoint mixing will try to grab the value of the next $breakpoints item which results in a null value. The compilation fails at subtracting (1/16) from null: `(Line 62: Invalid null operation: "null minus 0.0625".)`
