### PR TITLE
Changed hard toggle directive to close all the active components except ...

### DIFF
--- a/js/angular/common/common.directives.js
+++ b/js/angular/common/common.directives.js
@@ -75,7 +75,7 @@ angular.module('foundation.common.directives')
     restrict: 'A',
     link: function(scope, element, attrs) {
       element.on('click', function(e) {
-        foundationApi.closeActiveElements();
+        foundationApi.closeActiveElements({exclude: attrs.zfHardToggle});
         foundationApi.publish(attrs.zfHardToggle, 'toggle');
         e.preventDefault();
       });

--- a/js/angular/common/common.services.js
+++ b/js/angular/common/common.services.js
@@ -55,12 +55,15 @@ angular.module('foundation.common.services')
           element.removeClass(activeClass);
         }
       },
-      closeActiveElements: function() {
+      closeActiveElements: function(options) {
           var self = this;
+          options = options || {};
           var activeElements = document.querySelectorAll('.is-active[zf-closable]');
           if (activeElements.length) {
             angular.forEach(activeElements, function(el) {
-              self.publish(el.id, 'close');
+              if (options.exclude !== el.id) {
+                self.publish(el.id, 'close');
+              }
             });
           }
       },


### PR DESCRIPTION
Fixed https://github.com/zurb/foundation-apps/issues/303

With these changes, hard toggle will close all the active elements except the newly triggered component.
