### PR TITLE
Changed root module name from application to foundation

### DIFF
--- a/js/angular/app.js
+++ b/js/angular/app.js
@@ -1,7 +1,6 @@
-angular.module('application', [
+angular.module('foundation', [
     'ui.router',
     'ngAnimate',
-    'markdown',
     'foundation.init',
     'foundation.init.state',
     'foundation.common.services',


### PR DESCRIPTION
I think, root module name should be foundation instead of application.

This will let user to use module name "application"  to their project and they can add foundation as dependency.

Also, removed the markdown as dependency for root module.  
