### PR TITLE
Remove bottom margin on the menu-bar when it is a vertical primary menu.

### DIFF
--- a/scss/components/_menu-bar.scss
+++ b/scss/components/_menu-bar.scss
@@ -68,6 +68,9 @@ $menubar-icon-spacing: $menubar-item-padding !default;
     a {
       flex-flow: row nowrap;
     }
+    &.primary {
+      margin-bottom: 0;
+    }
   }
 
   /*


### PR DESCRIPTION
There generally wouldn't need to be any margin in this case as it would be a full height left or right justified navigation menu.
