### PR TITLE
Fixed collapsible issue in accordion

### DIFF
--- a/js/angular/components/accordion/accordion.js
+++ b/js/angular/components/accordion/accordion.js
@@ -26,10 +26,11 @@
           }
         } else {
           //non  multi open will close all tabs and open one
-          section.scope.active = false;
           if(section.scope === selectSection) {
             //if collapsible is allowed, a tab will toggle
-            section.scope.active = collapsible === true ? !section.scope.active : true;
+            section.scope.active = collapsible ? !section.scope.active : true;
+          } else {
+            section.scope.active = false;
           }
         }
 


### PR DESCRIPTION
Fix for issue #328 

``` js
section.scope.active = false;
if(section.scope === selectSection) {
     //if collapsible is allowed, a tab will toggle
     section.scope.active = collapsible === true ? !section.scope.active : true;
}
```

since active is forced to false before condition check, active of selected item is always true and collapsible has no effect.

Fixing this in this PR
