### PR TITLE
Fix #342 without expanding API

### DIFF
--- a/js/angular/components/iconic/iconic.js
+++ b/js/angular/components/iconic/iconic.js
@@ -26,6 +26,9 @@
   function zfIconic(iconic) {
     var directive = {
       restrict: 'A',
+      scope: {
+        dynSrc: '=?'
+      },
       link: link
     };
 
@@ -33,7 +36,12 @@
 
     function link(scope, element, attrs, controller) {
       var ico = iconic.getAccess();
-      attrs.$set('data-src', attrs.src);
+      if(scope.dynSrc) {
+         attrs.$set('data-src', scope.dynSrc);
+      } else {
+        // To support expressions on data-src
+        attrs.$set('data-src', attrs.src);
+      }
       ico.inject(element[0]);
     }
   }


### PR DESCRIPTION
@AntJanus,
when data-src is dynamically updated, angular is updating the src attribute value

So setting data-src value with src value is fixing #342 without introducing new attribute.
I tested the below example with this fix and it is working fine.

``` html
<ul ng-init="items=['assets/img/iconic/action.svg', 'assets/img/iconic/ban.svg', 'assets/img/iconic/bell.svg']">
  <li ng-repeat="item in items" >
  <img zf-iconic="" data-src={{item}} class="iconic-sm" >
  </li >
</ul>
```
