### PR TITLE
Undoing the fix for #323 implemented before animation cancellation

### DIFF
--- a/js/angular/components/common/common.js
+++ b/js/angular/components/common/common.js
@@ -155,18 +155,9 @@
 
     function link(scope, element, attrs) {
       element.on('click', function(e) {
-        var animatedElements = document.querySelectorAll('.ng-enter-active');
-        // if there are any currently animated elements on the page
-        // SIDENOTE: there is probably a more elegant way of doing this
-        if (animatedElements.length !== 0) {
-          e.preventDefault(); // do nothing
-        }
-        // else do the toggle thang
-        else {
-          foundationApi.closeActiveElements({exclude: attrs.zfHardToggle});
-          foundationApi.publish(attrs.zfHardToggle, 'toggle');
-          e.preventDefault();
-        }
+        foundationApi.closeActiveElements({exclude: attrs.zfHardToggle});
+        foundationApi.publish(attrs.zfHardToggle, 'toggle');
+        e.preventDefault();
       });
     }
   }


### PR DESCRIPTION
Since the animation-cancellation feature is implemented in foundation.core service, removing the previous fix that was added in hard-toggle  directive. It is creating other issues.

For example, if we click on left panel and then immediately click on right panel in docs, right panel never show up because it is cancelled in hard-toggle directive.