### PR TITLE
Renamed the ui-router bower dependency to angular-ui-router 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "tether": "~0.6.5",
     "fastclick": "~1.0.3",
     "angular": "~1.3.4",
-    "ui-router": "~0.2.12",
+    "angular-ui-router": "~0.2.12",
     "angular-animate": "~1.3.4",
     "angular-touch": "~1.3.7",
     "hammerjs": "~2.0.4"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ var foundationJS = [
   'bower_components/tether/tether.js',
   'bower_components/angular/angular.js',
   'bower_components/angular-animate/angular-animate.js',
-  'bower_components/ui-router/release/angular-ui-router.js',
+  'bower_components/angular-ui-router/release/angular-ui-router.js',
   'bower_components/hammerjs/hammer.js',
   'js/vendor/**/*.js',
   'js/angular/**/*.js',


### PR DESCRIPTION
UI router doc states the bower package is angular-ui-router
https://github.com/angular-ui/ui-router#get-started

If most people follow this doc, they will end up with 2 dependencies ui-router and angular-ui-router