### PR TITLE
Update angular.html

### DIFF
--- a/docs/templates/angular.html
+++ b/docs/templates/angular.html
@@ -300,7 +300,7 @@ FoundationApi.publish('my-modal', 'open');
 
 <p>Make sure to include FoundationApi as a dependency in the controller or wherever else you want to use it. The best bet to hooking into various directives is to check the code and see what each directive subscribes to.</p>
 
-<p>In fact, the directives <code/>zf-close<code>, <code>zf-open</code>, and <code>zf-toggle</code> are wrappers for FoundationApi events.</p>
+<p>In fact, the directives <code>zf-close</code>, <code>zf-open</code>, and <code>zf-toggle</code> are wrappers for FoundationApi events.</p>
 
 <h3>Building your own app</h3>
 


### PR DESCRIPTION
In line 306 the closing code element was in front of it's opening code element companion, causing the rest of the page to be in "code" format. I swapped them back to the proper order.