### PR TITLE
Focus modal on show

### DIFF
--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -73,6 +73,8 @@
         scope.show = function() {
           scope.active = true;
           animate();
+          dialog.tabIndex = -1;
+          dialog[0].focus();
           return;
         };
 


### PR DESCRIPTION
Should solve #192. Putting the focus back on the originating element is not possible right now since there might not be an originating element (such as when programmatically triggered). To enable triggering a refocus, the `zf-open` and `zf-toggle` directives would have to be redone. 