### PR TITLE
Motion-UI ng-stagger animations

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -462,6 +462,10 @@ $include-css: (
 //   in: "ng-enter-active",
 //   out: "ng-leave-active",
 // );
+// $motion-class-stagger: (
+//   in: "ng-enter-stagger",
+//   out: "ng-leave-stagger",
+// );
 
 // Set if movement-based transitions should also fade the element in and out
 // $motion-slide-and-fade: false;
@@ -474,6 +478,9 @@ $include-css: (
 // Slow and fast modifiders
 // $motion-duration-slow: 1.4s;
 // $motion-duration-fast: 300ms;
+// $motion-stagger-duration-default: 150ms;
+// $motion-stagger-duration-short: 50ms;
+// $motion-stagger-duration-long: 300ms;
 
 // Default timing function for transitions and animations
 // $motion-timing-default: ease;

--- a/scss/components/_motion.scss
+++ b/scss/components/_motion.scss
@@ -454,11 +454,6 @@ $motion-delay-long: 700ms !default;
   // Duration
   .slow { transition-duration: $motion-duration-slow !important; }
   .fast { transition-duration: $motion-duration-fast !important; }
-  // .slow-stagger { 
-  //   -webkit-transition-delay: $motion-stagger-duration-slow !important; 
-  //   transition-duration: $motion-stagger-duration-slow !important; 
-  // }
-  // .fast-stagger { transition-duration: $motion-stagger-duration-fast !important; }
 
   // Easing
   @each $easing in map-keys($motion-timings) {

--- a/scss/components/_motion.scss
+++ b/scss/components/_motion.scss
@@ -118,9 +118,7 @@ $motion-delay-long: 700ms !default;
 }
 
 @mixin stagger-delay($delay-amount) {
-  -webkit-transition-delay: $delay-amount;
   transition-delay: $delay-amount;
-  -webkit-transition-duration:0;
   // this is to avoid accidental CSS inheritance
   transition-duration:0;
 }

--- a/scss/components/_motion.scss
+++ b/scss/components/_motion.scss
@@ -109,30 +109,10 @@ $motion-delay-long: 700ms !default;
   }
 }
 
-
-@mixin stagger-wrap($dir, $class) {
-  $sel: map-get($motion-class-stagger, $dir);
-  &.#{$sel}.#{$class} {
-    @content;
-  }
-}
-
-@mixin stagger-delay($delay-amount) {
+@mixin stagger($delay-amount) {
   transition-delay: $delay-amount;
   // this is to avoid accidental CSS inheritance
   transition-duration:0;
-}
-
-@mixin stagger($dir) {
-  @include stagger-wrap($dir, 'stagger') {
-    @include stagger-delay($motion-stagger-duration-default);
-  }
-  @include stagger-wrap($dir, 'short-stagger') {
-    @include stagger-delay($motion-stagger-duration-short);
-  }
-  @include stagger-wrap($dir, 'long-stagger') {
-    @include stagger-delay($motion-stagger-duration-long);
-  }
 }
 
 
@@ -180,7 +160,6 @@ $motion-delay-long: 700ms !default;
 
     @if $fade { opacity: if($dir == in, 1, 0); }
   }
-  @include stagger($dir);
 }
 
 // FADE
@@ -200,7 +179,6 @@ $motion-delay-long: 700ms !default;
   @include transition-end($dir) {
     opacity: $to;
   }
-  @include stagger($dir);
 }
 
 // HINGE
@@ -275,7 +253,6 @@ $motion-delay-long: 700ms !default;
     transform: $end;
     @if $fade { opacity: if($dir == in, 1, 0); }
   }
-  @include stagger($dir);
 }
 
 // SCALE
@@ -298,7 +275,6 @@ $motion-delay-long: 700ms !default;
     transform: scale($to);
     @if $fade { opacity: if($dir == in, 1, 0) }
   }
-  @include stagger($dir);
 }
 
 // SPIN
@@ -499,4 +475,7 @@ $motion-delay-long: 700ms !default;
     &.delay       { animation-delay: $motion-delay-short !important; }
     &.long-delay  { animation-delay: $motion-delay-long !important; }
   }
+  .stagger { @include stagger($motion-stagger-duration-default); }
+  .stort-stagger { @include stagger($motion-stagger-duration-default); }
+  .long-stagger { @include stagger($motion-stagger-duration-default); }
 }

--- a/scss/components/_motion.scss
+++ b/scss/components/_motion.scss
@@ -26,6 +26,10 @@ $motion-class-active: (
   in: "ng-enter-active",
   out: "ng-leave-active",
 ) !default;
+$motion-class-stagger: (
+  in: "ng-enter-stagger",
+  out: "ng-leave-stagger",
+) !default;
 
 // Set if movement-based transitions should also fade the element in and out
 $motion-slide-and-fade: false !default;
@@ -38,6 +42,9 @@ $motion-duration-default: 700ms !default;
 // Slow and fast modifiders
 $motion-duration-slow: 1.4s !default;
 $motion-duration-fast: 300ms !default;
+$motion-stagger-duration-default: 150ms !default;
+$motion-stagger-duration-short: 50ms !default;
+$motion-stagger-duration-long: 300ms !default;
 
 // Default timing function for transitions and animations
 $motion-timing-default: ease !default;
@@ -90,6 +97,7 @@ $motion-delay-long: 700ms !default;
     @content;
   }
 }
+
 // Wraps content in an enter/leave active class, chained to the matching
 // enter/leave class, chained to the parent selector
 // Define the end state of a transition here
@@ -100,6 +108,35 @@ $motion-delay-long: 700ms !default;
     @content;
   }
 }
+
+
+@mixin stagger-wrap($dir, $class) {
+  $sel: map-get($motion-class-stagger, $dir);
+  &.#{$sel}.#{$class} {
+    @content;
+  }
+}
+
+@mixin stagger-delay($delay-amount) {
+  -webkit-transition-delay: $delay-amount;
+  transition-delay: $delay-amount;
+  -webkit-transition-duration:0;
+  // this is to avoid accidental CSS inheritance
+  transition-duration:0;
+}
+
+@mixin stagger($dir) {
+  @include stagger-wrap($dir, 'stagger') {
+    @include stagger-delay($motion-stagger-duration-default);
+  }
+  @include stagger-wrap($dir, 'short-stagger') {
+    @include stagger-delay($motion-stagger-duration-short);
+  }
+  @include stagger-wrap($dir, 'long-stagger') {
+    @include stagger-delay($motion-stagger-duration-long);
+  }
+}
+
 
 // 1. Base Transitions
 // - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -145,6 +182,7 @@ $motion-delay-long: 700ms !default;
 
     @if $fade { opacity: if($dir == in, 1, 0); }
   }
+  @include stagger($dir);
 }
 
 // FADE
@@ -164,6 +202,7 @@ $motion-delay-long: 700ms !default;
   @include transition-end($dir) {
     opacity: $to;
   }
+  @include stagger($dir);
 }
 
 // HINGE
@@ -238,6 +277,7 @@ $motion-delay-long: 700ms !default;
     transform: $end;
     @if $fade { opacity: if($dir == in, 1, 0); }
   }
+  @include stagger($dir);
 }
 
 // SCALE
@@ -260,6 +300,7 @@ $motion-delay-long: 700ms !default;
     transform: scale($to);
     @if $fade { opacity: if($dir == in, 1, 0) }
   }
+  @include stagger($dir);
 }
 
 // SPIN
@@ -413,6 +454,11 @@ $motion-delay-long: 700ms !default;
   // Duration
   .slow { transition-duration: $motion-duration-slow !important; }
   .fast { transition-duration: $motion-duration-fast !important; }
+  // .slow-stagger { 
+  //   -webkit-transition-delay: $motion-stagger-duration-slow !important; 
+  //   transition-duration: $motion-stagger-duration-slow !important; 
+  // }
+  // .fast-stagger { transition-duration: $motion-stagger-duration-fast !important; }
 
   // Easing
   @each $easing in map-keys($motion-timings) {


### PR DESCRIPTION
Added stagger animation classes that work with existing Motion-UI classes per [issue 238](https://github.com/zurb/foundation-apps/issues/238). 

* `.stagger`, `.short-stagger` and `.long-stagger` classes can be added in conjunction with existing motion-ui classes
* Ng class names can be changed via `$motion-class-stagger`
* Added 3 mixins: `@stagger-wrap`, `@stagger-delay` and `@stagger`
* Typical use case is to add presentational classes by appending `@include stagger($dir);` to the end of existing mixin(s) ( i.e. `@slide( ... )` )

**NOTE**: Not all ng structures support this out of the box. You might have to add the `ng-animate-children` attribute to a `ng-repeat` element for the animation to work correctly. 

One example of this is using `ng-init` for quickly prototyping simple json structures. Please see [my comment on issue 238](https://github.com/zurb/foundation-apps/issues/238#issuecomment-68087707) for an example of this. 

Alternatively data received via firebase-angular and looped via `ng-repeat` supported this out of the box. No further testing was done against other data sources.

Please see the [ngAnimate docs](https://docs.angularjs.org/api/ngAnimate), specifically "Staggering CSS Animations" for more details.