### PR TITLE
Set autoscroll on ui-view

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
         <div class="medium-9 large-10 grid-content" ng-show="$state.current.name.length">
           <div class="grid-container main-docs-section">
             <a class="small secondary expand button hide-for-medium" zf-toggle="sidebar">Show Components</a>
-            <div ng-class="['ui-animation']" ui-view></div>
+            <div ng-class="['ui-animation']" ui-view autoscroll></div>
           </div>
 
           <div class="zurb-footer-top">


### PR DESCRIPTION
Documentation pages not scrolling to top of page.

It's a minor one, but a bit annoying when reading the docs. 
https://github.com/angular-ui/ui-router/wiki/Quick-Reference#ui-view

