### PR TITLE
Correct duplicate menu-bar-style mixin parameter

### DIFF
--- a/docs/templates/menu-bar.html
+++ b/docs/templates/menu-bar.html
@@ -282,7 +282,7 @@ title: Menu Bar
   @include menu-bar-style(
     $background: #000, // Background color of items
     $background-hover: #333, // Background color of item on hover
-    $background-hover: #666, // Background color of an active item
+    $background-active: #666, // Background color of an active item
     $color: #fff, // Text color of items
     $color-hover, // Text color of item on hover
     $color-active, // Text color of item when active


### PR DESCRIPTION
Extending the menu bar by copying from the documentation was failing due to duplicate mixin parameter.