### PR TITLE
Adjust select padding to avoid text arrow overlap

### DIFF
--- a/docs/templates/forms.html
+++ b/docs/templates/forms.html
@@ -35,6 +35,7 @@ title: Forms
         <option value="">Breakfast</option>
         <option value="">Bacon Pancakes</option>
         <option value="">Mountain Dew</option>
+        <option value="">Scrambled eggs with grilled zucchini, spinach, leeks, roasted tomatoes and mozzarella</option>
       </select>
     </div>
     <div class="small-12 medium-6 grid-content">
@@ -81,6 +82,7 @@ title: Forms
             <option value="">Breakfast</option>
             <option value="">Bacon Pancakes</option>
             <option value="">Mountain Dew</option>
+            <option value="">Scrambled eggs with grilled zucchini, spinach, leeks, roasted tomatoes and mozzarella</option>
           </select>
         </div>
         <div class="small-12 medium-6 grid-content">

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -207,6 +207,7 @@ select {
   @if $select-arrow {
     background: $select-background url(image-triangle($select-arrow-color)) right 10px center no-repeat;
     background-size: 8px 8px;
+    padding-right: 18px;
   }
   @else {
     background-color: $select-background


### PR DESCRIPTION
Currently select option text may overlap the arrow. This PR adds additional right padding to avoid this.

Before:
![forms](https://cloud.githubusercontent.com/assets/755/5899405/0005cddc-a55b-11e4-9d3e-1640dd80968d.png)

After (this PR):
![forms](https://cloud.githubusercontent.com/assets/755/5899416/1ef440b6-a55b-11e4-9067-b8d467e89b63.png)

After (#417, alternative PR with extra padding):
![forms](https://cloud.githubusercontent.com/assets/755/5899434/64ecbc60-a55b-11e4-82e2-e29aecb855df.png)
