### PR TITLE
Add custom data to states from front matter

### DIFF
--- a/js/angular/services/foundation.dynamicRouting.js
+++ b/js/angular/services/foundation.dynamicRouting.js
@@ -46,7 +46,9 @@
             controller: getController(page),
             data: { vars: page },
           };
-
+          
+          angular.extend(state.data, page.data);
+          
           $stateProvider.state(page.name, state);
         }
       });
@@ -60,7 +62,9 @@
               '': buildState(page.path, page)
             }
           };
-
+          
+          angular.extend(state.data, page.data);
+          
           angular.forEach(page.children, function(sub) {
             state.views[sub.name + '@' + page.name] = buildState(sub.path, page);
           });

--- a/js/angular/services/foundation.dynamicRouting.js
+++ b/js/angular/services/foundation.dynamicRouting.js
@@ -44,10 +44,8 @@
             templateUrl: page.path,
             parent: page.parent || '',
             controller: getController(page),
-            data: { vars: page },
+            data: getData(page),
           };
-          
-          angular.extend(state.data, page.data);
           
           $stateProvider.state(page.name, state);
         }
@@ -57,13 +55,11 @@
           var state = {
             url: page.url,
             parent: page.parent || '',
-            data: { vars: page },
+            data: getData(page),
             views: {
               '': buildState(page.path, page)
             }
           };
-          
-          angular.extend(state.data, page.data);
           
           angular.forEach(page.children, function(sub) {
             state.views[sub.name + '@' + page.name] = buildState(sub.path, page);
@@ -74,7 +70,21 @@
     };
 
     this.$get = angular.noop;
-
+    
+    function getData(page) {
+      var data = { vars: {} };
+      if (page.data) {
+        if (typeof page.data.vars === "object") {
+          data.vars = page.data.vars;
+        }
+        delete page.data.vars;
+        angular.extend(data, page.data);
+      }
+      delete page.data;
+      angular.extend(data.vars, page);
+      return data;
+    }
+    
     function buildState(path, state) {
       return {
         templateUrl: path,


### PR DESCRIPTION
Provide access to add custom data to state objects from front matter.  I needed to add custom data for route authentication, but this could be useful for others and their purposes as well.


Template Front Matter
```html
---
name: main
url: /
animationIn: fadeIn
data: { requiresLogin: true }
---
```

Added to DynamicRouting 
```javascript
angular.extend(state.data, page.data);
```