### PR TITLE
use pinAt to pass targetAttachment in popup directive

### DIFF
--- a/js/angular/components/popup/popup.js
+++ b/js/angular/components/popup/popup.js
@@ -38,6 +38,7 @@
         scope.target = scope.target || false;
 
         var attachment = scope.pinTo || 'top center';
+        var targetAttachment = scope.pinAt || 'bottom center';
         var tetherInit = false;
         var tether     = {};
 
@@ -96,6 +97,7 @@
             element: element[0],
             target: scope.target,
             attachment: attachment,
+            targetAttachment: targetAttachment,
             enable: false
           });
 


### PR DESCRIPTION
With the above two lines the pinAt value is actually passed on to the tether instance. It seems that the pinAt property was already meant for passing the targetAttachment of the tether instance that is created in popup.js.