### PR TITLE
Updates to iconic directive to broadcast when svg injection is completed

### DIFF
--- a/js/angular/app.js
+++ b/js/angular/app.js
@@ -4,6 +4,7 @@
   angular.module('application', [
     'ui.router',
     'ngAnimate',
+    'ngSVGAttributes',
 
     //foundation
     'foundation',
@@ -20,15 +21,22 @@
     $urlProvider.otherwise('/');
 
     $locationProvider.html5Mode({
-      enabled:false,
+      enabled:true,
       requireBase: false
     });
-
-    $locationProvider.hashPrefix('!');
   }
+  
+  run.$inject = ['$rootScope', '$location', '$compile'];
 
-  function run() {
+  function run($rootScope, $location, $compile) {
     FastClick.attach(document.body);
+    
+    if ($location.$$html5) {
+      $rootScope.$on('$zfIconicInjected', function(event, injectedElem) {
+        var angElem = angular.element(injectedElem);
+        $compile(angElem.contents())(angElem.scope());
+      });
+    }
   }
 
 })();

--- a/js/angular/components/iconic/iconic.js
+++ b/js/angular/components/iconic/iconic.js
@@ -21,9 +21,9 @@
     }
   }
 
-  zfIconic.$inject = ['Iconic', 'FoundationApi']
+  zfIconic.$inject = ['Iconic', 'FoundationApi', '$location']
 
-  function zfIconic(iconic, foundationApi) {
+  function zfIconic(iconic, foundationApi, $location) {
     var directive = {
       restrict: 'A',
       template: '<img ng-transclude>',
@@ -52,7 +52,11 @@
           iAttrs.$set('data-src', scope.dynSrc);
         } else {
           // To support expressions on data-src
-          iAttrs.$set('data-src', assetPath + scope.icon + '.svg');
+          if (scope.icon) {
+            iAttrs.$set('data-src', assetPath + scope.icon + '.svg');
+          } else {
+            iAttrs.$set('data-src', iAttrs.src);
+          }
         };
 
         var iconicClass;
@@ -75,7 +79,13 @@
       function postLink(scope, element, attrs) {
         var ico = iconic.getAccess();
 
-        ico.inject(element[0]);
+        ico.inject(element[0], {
+          each: function(injectedElem) {
+            if ($location.$$html5) {
+              scope.$emit('$zfIconicInjected', injectedElem);
+            }
+          }
+        });
 
         foundationApi.subscribe('resize', function() {
           ico.update();

--- a/js/angular/components/iconic/iconic.js
+++ b/js/angular/components/iconic/iconic.js
@@ -21,9 +21,9 @@
     }
   }
 
-  zfIconic.$inject = ['Iconic', 'FoundationApi', '$location']
+  zfIconic.$inject = ['Iconic', 'FoundationApi', '$compile', '$location']
 
-  function zfIconic(iconic, foundationApi, $location) {
+  function zfIconic(iconic, foundationApi, $compile, $location) {
     var directive = {
       restrict: 'A',
       template: '<img ng-transclude>',
@@ -31,6 +31,7 @@
       replace: true,
       scope: {
         dynSrc: '=?',
+        dynIcon: '=?',
         size: '@?',
         icon: '@'
       },
@@ -40,24 +41,26 @@
     return directive;
 
     function compile() {
+      var contents, assetPath = 'assets/img/iconic/';
+      
       return {
         pre: preLink,
         post: postLink
       };
 
       function preLink(scope, iElement, iAttrs, ctrl, transclude) {
-        var assetPath = 'assets/img/iconic/';
-
         if(scope.dynSrc) {
           iAttrs.$set('data-src', scope.dynSrc);
+        } else if(scope.dynIcon) {
+          iAttrs.$set('data-src', assetPath + scope.dynIcon + '.svg');
         } else {
-          // To support expressions on data-src
           if (scope.icon) {
             iAttrs.$set('data-src', assetPath + scope.icon + '.svg');
           } else {
+            // To support expressions on data-src
             iAttrs.$set('data-src', iAttrs.src);
           }
-        };
+        }
 
         var iconicClass;
         switch (scope.size) {
@@ -74,22 +77,59 @@
             iconicClass = 'iconic-fluid'
         }
         angular.element(iElement).addClass(iconicClass);
+        
+        // save contents of un-inject html, to use for dynamic re-injection
+        contents = iElement[0].outerHTML;
       }
 
       function postLink(scope, element, attrs) {
-        var ico = iconic.getAccess();
+        var svgElement, ico = iconic.getAccess();
 
-        ico.inject(element[0], {
-          each: function(injectedElem) {
-            if ($location.$$html5) {
-              scope.$emit('$zfIconicInjected', injectedElem);
-            }
-          }
-        });
+        injectSvg(element[0]);
 
         foundationApi.subscribe('resize', function() {
-          ico.update();
+          // only run update on current element
+          ico.update(element[0]);
         });
+        
+        // handle dynamic updating of icon
+        if(scope.dynSrc) {
+          scope.$watch('dynSrc', function(newVal, oldVal) {
+            if (newVal && newVal != oldVal) {
+              reinjectSvg(scope.dynSrc);
+            }
+          });
+        }
+        if (scope.dynIcon) {
+          scope.$watch('dynIcon', function(newVal, oldVal) {
+            if (newVal && newVal != oldVal) {
+              reinjectSvg(assetPath + scope.dynIcon + '.svg');
+            }
+          });
+        }
+        
+        function reinjectSvg(newSrc) {
+          if (svgElement) {
+            // set html
+            svgElement.empty();
+            svgElement.append(angular.element(contents));
+            
+            // set new source
+            svgElement.attr('data-src', newSrc);
+            
+            // reinject
+            injectSvg(svgElement[0]);
+          }
+        }
+
+        function injectSvg(element) {
+          ico.inject(element, {
+            each: function(injectedElem) {
+              var angElem = angular.element(injectedElem);
+              svgElement = $compile(angElem)(angElem.scope());
+            }
+          });
+        }
       }
     }
   }

--- a/js/angular/vendor/svgDirs.js
+++ b/js/angular/vendor/svgDirs.js
@@ -1,0 +1,101 @@
+'use strict';
+
+(function(){
+  var svgDirectives = {};
+
+  angular.forEach([
+      'clipPath',
+      'colorProfile',
+      'src',
+      'cursor',
+      'fill',
+      'filter',
+      'marker',
+      'markerStart',
+      'markerMid',
+      'markerEnd',
+      'mask',
+      'stroke'
+    ],
+    function(attr) {
+      svgDirectives[attr] = [
+          '$rootScope',
+          '$location',
+          '$interpolate',
+          '$sniffer',
+          'urlResolve',
+          'computeSVGAttrValue',
+          'svgAttrExpressions',
+          function(
+              $rootScope,
+              $location,
+              $interpolate,
+              $sniffer,
+              urlResolve,
+              computeSVGAttrValue,
+              svgAttrExpressions) {
+            return {
+              restrict: 'A',
+              link: function(scope, element, attrs) {
+                var initialUrl;
+
+                //Only apply to svg elements to avoid unnecessary observing
+                //Check that is in html5Mode and that history is supported
+                if ((!svgAttrExpressions.SVG_ELEMENT.test(element[0] &&
+                    element[0].toString())) ||
+                  !$location.$$html5 ||
+                  !$sniffer.history) return;
+
+                //Assumes no expressions, since svg is unforgiving of xml violations
+                initialUrl = attrs[attr];
+                attrs.$observe(attr, updateValue);
+                $rootScope.$on('$locationChangeSuccess', updateValue);
+
+                function updateValue () {
+                  var newVal = computeSVGAttrValue(initialUrl);
+                  //Prevent recursive updating
+                  if (newVal && attrs[attr] !== newVal) attrs.$set(attr, newVal);
+                }
+              }
+            };
+          }];
+  });
+
+  angular.module('ngSVGAttributes', []).
+    factory('urlResolve', [function() {
+      //Duplicate of urlResolve & urlParsingNode in angular core
+      var urlParsingNode = document.createElement('a');
+      return function urlResolve(url) {
+        urlParsingNode.setAttribute('href', url);
+        return urlParsingNode;
+      };
+    }]).
+    value('svgAttrExpressions', {
+      FUNC_URI: /^url\((.*)\)$/,
+      SVG_ELEMENT: /SVG[a-zA-Z]*Element/,
+      HASH_PART: /#.*/
+    }).
+    factory('computeSVGAttrValue', [
+                '$location', '$sniffer', 'svgAttrExpressions', 'urlResolve',
+        function($location,   $sniffer,   svgAttrExpressions,   urlResolve) {
+          return function computeSVGAttrValue(url) {
+            var match, fullUrl;
+            if (match = svgAttrExpressions.FUNC_URI.exec(url)) {
+              //hash in html5Mode, forces to be relative to current url instead of base
+              if (match[1].indexOf('#') === 0) {
+                fullUrl = $location.absUrl().
+                  replace(svgAttrExpressions.HASH_PART, '') +
+                  match[1];
+              }
+              //Presumably links to external SVG document
+              else {
+                fullUrl = urlResolve(match[1]);
+              }
+            }
+            return fullUrl ? 'url(' + fullUrl + ')' : null;
+          };
+        }
+      ]
+    ).
+    directive(svgDirectives);
+}());


### PR DESCRIPTION
First off, I'm new to using GitHub, so forgive me if I'm not following the proper practices for submitting requests.

I recently switched a project I built using Foundation for Apps to use HTML5 mode, mainly for prettier urls.  I followed the instructions laid out in the [documentation](https://docs.angularjs.org/guide/$location).  After doing so, I noticed the iconic SVGs weren't loading properly.  After some investigation I found that the issue was caused by the iconic urls only containing hash fragments.  As called out in the HTML5 mode documentation:

>There is one exception: Links that only contain a hash fragment (e.g. `<a href="#target">`) will only change $location.hash() and not modify the url otherwise.

For more info see AngularJS issue [#8934](https://github.com/angular/angular.js/issues/8934). I found a solution which will rewrite all urls in FuncIRI notation to an absolute url using the specified base: https://github.com/jeffbcross/angular-svg-base.  The library works great for content loaded that angular is aware of, however, the [svg injector library](https://github.com/iconic/SVGInjector) being used in the framework does not notify angular once an svg is added to the DOM. The solution to the fix is to compile the new SVG element once it's been added to the DOM using angular's $compile.

My proposal is to have the framework broadcast a message when iconic has finished updating the DOM to include the injected SVG.  Luckily, the svg injection library provides a callback for such a case.  This is only required for HTML5 mode, as the hash fragment urls will work properly otherwise.  The proposed solution does not directly call $compile as not all apps would need angular to be aware of the injected svg element, only those which have specified the url base in the head of index.html (i.e. apps using html5 mode).

Also included in the changes is a fix to the iconic directive for which a previous change broke backwards compatibility.  The previous change caused elements which already used data-src to become invalidated and replaced with 'assets/img/iconic/undefined.svg'.  That change can be moved to another PR if desired.