### PR TITLE
Fix params initialization in DefaultController

### DIFF
--- a/js/angular/services/foundation.dynamicRouting.js
+++ b/js/angular/services/foundation.dynamicRouting.js
@@ -106,7 +106,7 @@
   DefaultController.$inject = ['$scope', '$stateParams', '$state'];
 
   function DefaultController($scope, $stateParams, $state) {
-    var params = [];
+    var params = {};
     angular.forEach($stateParams, function(value, key) {
       params[key] = value;
     });


### PR DESCRIPTION
`params` is initialized to an array, but is used as an object. This results in the DefaultController's $scope.params property to be invalid. More detail can be found here: https://github.com/zurb/foundation-apps/issues/437