### PR TITLE
Bug fix: block list labels with checkbox and radios are not block widths...

### DIFF
--- a/scss/components/_block-list.scss
+++ b/scss/components/_block-list.scss
@@ -280,6 +280,7 @@ $blocklist-check-icons: true !default;
     left: -9999px;
 
     & + label {
+      display: block;
       font-size: $blocklist-fontsize;
       margin: 0;
     }


### PR DESCRIPTION
... (inputs were flush with the labels).

Below is an image of problem before `display: block;` on labels with radio button and checkbox siblings:

![block list label bug](http://ibin.co/1rRaMrQFOiyI)