### PR TITLE
newTarget is not defined error on publish event in Popup

### DIFF
--- a/js/angular/components/popup/popup.js
+++ b/js/angular/components/popup/popup.js
@@ -86,7 +86,7 @@
 
         scope.hide = function() {
           scope.active = false;
-          tetherElement(newTarget);
+          tetherElement();
           tether.disable();
           return;
         };


### PR DESCRIPTION
When you publish a 'hide' event, newTarget is undefined, resulting in an error being thrown.