### PR TITLE
Grid units rework

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -84,8 +84,14 @@ $foundation-colors: (
     box-sizing: inherit;
   }
 
+  html, body, .grid-frame {
+    height: 100% !important;
+    overflow: hidden !important;
+  }
+
   // Default body styles
   body {
+    overflow: hidden;
     background: $body-background;
     color: $body-font-color;
     padding: 0;

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -47,7 +47,7 @@ $block-grid-max-size: 6 !default;
 		flex: 0 0 auto;
 	}
 	@else if ($size == expand) {
-		flex: 1 1;
+		flex: 1 1 auto;
 	}
 }
 /*


### PR DESCRIPTION
Right now we size the grid frame using `100vh`, which makes it 100% the height of the viewport. We use this to ensure the grid frame is the full width *and* height of the viewport. *But as it turns out*, we may have never needed `100vh` in the first place. This seems to accomplish the same effect:

```scss
html, body, .grid-frame {
  height: 100%;
}
```

If it works, there are two main benefits. First, we can drop the viewport unit polyfill for iOS 7 we're using. Second, iOS will stop butchering the `vh` unit. Mobile Safari seems to calculate `vh` by including the height of the address bar and the action bar at the bottom. That magic shrinking header also just makes our apps look janky.

This new approach seems to work well, but we need to test it thoroughly. Switching to this method also re-introduced an intermittent issue we had with iOS, where sometimes the browser tried to scroll the entire body instead of an inner grid element. There may be a way around it by killing scroll events that bubble up to the `<body>` element.