### PR TITLE
Bug fix: Display flex on grid-container

### DIFF
--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -350,6 +350,7 @@ $block-grid-max-size: 6 !default;
     }
   }
   .grid-container {
+    display: flex;
     @include grid-container;
 
     &.contain-left  { @include grid-container($align: left); }


### PR DESCRIPTION
Without `display: flex;` on `.grid-container`s, this scenario fails.

```
<div class="grid-container small-up-3">
    <div>Item 1</div>
    <div>Item 2</div>
    <div>Item 3</div>
</div>
```