### PR TITLE
feat(Iconic): add provider to make 'assetPath' configurable

### DIFF
--- a/js/angular/components/iconic/iconic.js
+++ b/js/angular/components/iconic/iconic.js
@@ -1,29 +1,59 @@
-(function() {
+(function () {
   'use strict';
 
   angular.module('foundation.iconic', [])
-    .service('Iconic', iconic)
+    .provider('Iconic', Iconic)
     .directive('zfIconic', zfIconic)
   ;
 
-  //iconic wrapper
-  function iconic() {
-    var iconicObject = IconicJS();
+  // iconic wrapper
+  function Iconic() {
+    // default path
+    var assetPath = 'assets/img/iconic/';
 
-    var service = {};
+    /**
+     * Sets the path used to locate the iconic SVG files
+     * @param {string} path - the base path used to locate the iconic SVG files
+     */
+    this.setAssetPath = function (path) {
+      assetPath = angular.isString(path) ? path : assetPath;
+    };
 
-    service.getAccess = getAccess;
+    /**
+     * Service implementation
+     * @returns {{}}
+     */
+    this.$get = function () {
+      var iconicObject = new IconicJS();
 
-    return service;
+      var service = {
+        getAccess: getAccess,
+        getAssetPath: getAssetPath
+      };
 
-    function getAccess() {
-      return iconicObject;
-    }
+      return service;
+
+      /**
+       *
+       * @returns {Window.IconicJS}
+       */
+      function getAccess() {
+        return iconicObject;
+      }
+
+      /**
+       *
+       * @returns {string}
+       */
+      function getAssetPath() {
+        return assetPath;
+      }
+    };
   }
 
-  zfIconic.$inject = ['Iconic', 'FoundationApi', '$compile', '$location']
+  zfIconic.$inject = ['Iconic', 'FoundationApi', '$compile'];
 
-  function zfIconic(iconic, foundationApi, $compile, $location) {
+  function zfIconic(iconic, foundationApi, $compile) {
     var directive = {
       restrict: 'A',
       template: '<img ng-transclude>',
@@ -43,27 +73,29 @@
 
     function compile() {
       var contents, assetPath;
-      
+
       return {
         pre: preLink,
         post: postLink
       };
 
-      function preLink(scope, element, attrs, ctrl, transclude) {
+      function preLink(scope, element, attrs) {
+
         if (scope.iconDir) {
-          // make sure ends with /
+          // path set via attribute
           assetPath = scope.iconDir;
-          if (assetPath.charAt(assetPath.length - 1) !== '/') {
-            assetPath += '/';
-          }
         } else {
           // default path
-          assetPath = 'assets/img/iconic/';
+          assetPath = iconic.getAssetPath();
         }
-        
-        if(scope.dynSrc) {
+        // make sure ends with /
+        if (assetPath.charAt(assetPath.length - 1) !== '/') {
+          assetPath += '/';
+        }
+
+        if (scope.dynSrc) {
           attrs.$set('data-src', scope.dynSrc);
-        } else if(scope.dynIcon) {
+        } else if (scope.dynIcon) {
           attrs.$set('data-src', assetPath + scope.dynIcon + '.svg');
         } else {
           if (scope.icon) {
@@ -75,26 +107,24 @@
         }
 
         // check if size already added as class
-        if (!element.hasClass('iconic-sm') && 
-            !element.hasClass('iconic-md') &&
-            !element.hasClass('iconic-lg')) {
+        if (!element.hasClass('iconic-sm') && !element.hasClass('iconic-md') && !element.hasClass('iconic-lg')) {
           var iconicClass;
           switch (scope.size) {
             case 'small':
-              iconicClass = 'iconic-sm'
+              iconicClass = 'iconic-sm';
               break;
             case 'medium':
-              iconicClass = 'iconic-md'
+              iconicClass = 'iconic-md';
               break;
             case 'large':
-              iconicClass = 'iconic-lg'
+              iconicClass = 'iconic-lg';
               break;
             default:
-              iconicClass = 'iconic-fluid'
+              iconicClass = 'iconic-fluid';
           }
           element.addClass(iconicClass);
         }
-        
+
         // save contents of un-inject html, to use for dynamic re-injection
         contents = element[0].outerHTML;
       }
@@ -104,37 +134,37 @@
 
         injectSvg(element[0]);
 
-        foundationApi.subscribe('resize', function() {
+        foundationApi.subscribe('resize', function () {
           // only run update on current element
           ico.update(element[0]);
         });
 
         // handle dynamic updating of src
-        if(scope.dynSrc) {
-          scope.$watch('dynSrc', function(newVal, oldVal) {
-            if (newVal && newVal != oldVal) {
+        if (scope.dynSrc) {
+          scope.$watch('dynSrc', function (newVal, oldVal) {
+            if (newVal && newVal !== oldVal) {
               reinjectSvg(scope.dynSrc);
             }
           });
         }
         // handle dynamic updating of icon
         if (scope.dynIcon) {
-          scope.$watch('dynIcon', function(newVal, oldVal) {
-            if (newVal && newVal != oldVal) {
+          scope.$watch('dynIcon', function (newVal, oldVal) {
+            if (newVal && newVal !== oldVal) {
               reinjectSvg(assetPath + scope.dynIcon + '.svg');
             }
           });
         }
-        
+
         function reinjectSvg(newSrc) {
           if (svgElement) {
             // set html
             svgElement.empty();
             svgElement.append(angular.element(contents));
-            
+
             // set new source
             svgElement.attr('data-src', newSrc);
-            
+
             // reinject
             injectSvg(svgElement[0]);
           }
@@ -142,7 +172,7 @@
 
         function injectSvg(element) {
           ico.inject(element, {
-            each: function(injectedElem) {
+            each: function (injectedElem) {
               // compile injected svg
               var angElem = angular.element(injectedElem);
               svgElement = $compile(angElem)(angElem.scope());


### PR DESCRIPTION
We are using the paid version of the awesome [Iconic](https://useiconic.com/) icons. Thus the default ```assetPath``` in the ```iconic``` service doesn't necessarily fit.
So I changed the service to a provider that can be configured via ```IconicProvider.setAssetPath(path)```. If no ```path``` is configured, the default value ```assets/img/iconic/``` is used.