### PR TITLE
Update modal.js where scope.$root is null

### DIFF
--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -110,7 +110,7 @@
             scope.toggle();
           }
 
-          if (!scope.$root.$$phase) {
+          if (scope.$root && !scope.$root.$$phase) {
             scope.$apply();
           }
 


### PR DESCRIPTION
Updated modal.js to fix a bug where somehow scope.$root could be null after a state change.