### PR TITLE
Fixed issue with autoclose for dynamically added notifications

### DIFF
--- a/js/angular/components/notification/notification.js
+++ b/js/angular/components/notification/notification.js
@@ -145,6 +145,14 @@
         //due to dynamic insertion of DOM, we need to wait for it to show up and get working!
         setTimeout(function() {
           scope.active = true;
+          
+          // close if autoclose
+          if (scope.autoclose) {
+            setTimeout(function() {
+              scope.hide();
+            }, parseInt(scope.autoclose));
+          };
+          
           foundationApi.animate(element, scope.active, animationIn, animationOut);
         }, 50);
 


### PR DESCRIPTION
The autoclose functionality never triggers because scope.active is only set to true after the timeout on line 146, thus scope.active on line 160 (line 168 new) is always false and thus the autoclose timeout is never triggered.  Adding the autoclose timeout after setting scope.active to true resolves this issue.