### PR TITLE
Allow configuring root directory for gulp-dynamic-routing

### DIFF
--- a/bin/gulp-dynamic-routing.js
+++ b/bin/gulp-dynamic-routing.js
@@ -7,7 +7,7 @@ var fs           = require('fs');
 
 module.exports = function(options) {
   var configs = [];
-  var directory = process.cwd();
+  var directory = options.dir || process.cwd();
 
   function bufferContents(file, enc, cb) {
     var config;


### PR DESCRIPTION
I have two apps I built with F4A, each with their own gulp file.  All common logic for building the apps are in a single gulp file outside the root directory of those two apps.  That single gulp files uses F4A's gulp-dynamic-routing.  In order to support this layout, I need the root directory to be configurable in the routing plugin.