### PR TITLE
Possible fix for issue 481

### DIFF
--- a/js/angular/services/foundation.core.animation.js
+++ b/js/angular/services/foundation.core.animation.js
@@ -56,11 +56,16 @@
       element[0].style.transitionDuration = '';
       element.addClass(activeClass);
 
-      element.one(events.join(' '), function() {
-        finishAnimation();
-      });
+      element.on(events.join(' '), eventHandler);
 
-      setTimeout(function() {
+      function eventHandler(e) {
+        if (element[0] === e.path[0]) {
+          clearTimeout(animationTimeout);
+          finishAnimation();
+        }
+      }
+
+      var animationTimeout = setTimeout(function() {
         if(timedOut) {
           finishAnimation();
         }
@@ -73,6 +78,7 @@
         element.removeClass(!activation ? activeGenericClass : ''); //if not active, remove active class
         reflow();
         timedOut = false;
+        element.off(events.join(' '), eventHandler);
       }
 
 

--- a/js/angular/services/foundation.core.animation.js
+++ b/js/angular/services/foundation.core.animation.js
@@ -58,18 +58,18 @@
 
       element.on(events.join(' '), eventHandler);
 
-      function eventHandler(e) {
-        if (element[0] === e.target) {
-          clearTimeout(animationTimeout);
-          finishAnimation();
-        }
-      }
-
       var animationTimeout = setTimeout(function() {
         if(timedOut) {
           finishAnimation();
         }
       }, 3000);
+
+      function eventHandler(e) {
+        if (element[0].id === e.target.id) {
+          clearTimeout(animationTimeout);
+          finishAnimation();
+        }
+      }
 
       function finishAnimation() {
         deregisterElement(element);

--- a/js/angular/services/foundation.core.animation.js
+++ b/js/angular/services/foundation.core.animation.js
@@ -65,7 +65,7 @@
       }, 3000);
 
       function eventHandler(e) {
-        if (element[0].id === e.target.id) {
+        if (element[0] === e.target) {
           clearTimeout(animationTimeout);
           finishAnimation();
         }

--- a/js/angular/services/foundation.core.animation.js
+++ b/js/angular/services/foundation.core.animation.js
@@ -59,7 +59,7 @@
       element.on(events.join(' '), eventHandler);
 
       function eventHandler(e) {
-        if (element[0] === e.path[0]) {
+        if (element[0] === e.target) {
           clearTimeout(animationTimeout);
           finishAnimation();
         }


### PR DESCRIPTION
I originally thought it was due to the display property being set to none for the panels, which is sort of true, but I believe now that the root cause is the panel's animation event listener.  It was picking up the transitionend events for the child zf-open button element, it transform's the background-color property.  

Since the transition for the button color occurs rather quickly, the panel runs finishAnimation too soon, setting the display property to none and canceling the transitionend event for the the child panel.

All in all, I think it be tighter if the element would verify that the `transitionend` event to execute on is for the transition on itself as the target.  Allowing panels to support child elements with transitions/animations without effecting it's own.

Instead of element.one(), use .on() and .off() to allow the eventHandler to find the correct transition to run on.  Also, I set a clearTimeout in the handler to stop the setTimeout function from running if it doesn't need to.  Thinking about using $timeout if necessary in the future.  I also changed it to just check if same matching id.

````javascript
      element.on(events.join(' '), eventHandler);

      function eventHandler(e) {
        if (element[0].id === e.target.id) {
          clearTimeout(animationTimeout);
          finishAnimation();
        }
      }

      var animationTimeout = setTimeout(function() {
        if(timedOut) {
          finishAnimation();
        }
      }, 3000);

      function finishAnimation() {
        deregisterElement(element);
        reset(); //reset all classes
        element[0].style.transitionDuration = '';
        element.removeClass(!activation ? activeGenericClass : ''); //if not active, remove active class
        reflow();
        timedOut = false;
        element.off(events.join(' '), eventHandler);
      }
````