### PR TITLE
Add case for "overlayClose" -> "overlay-close" ModalFactory property

### DIFF
--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -260,7 +260,7 @@
                 element.attr('animation-out', config[prop]);
                 break;
               case 'overlayClose':
-                element.attr('overlay-close', config[prop]);
+                element.attr('overlay-close', config[prop] ? 'true' : 'false'); // must be string, see postLink() above
                 break;
               default:
                 element.attr(prop, config[prop]);

--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -258,6 +258,9 @@
               case 'animationOut':
                 element.attr('animation-out', config[prop]);
                 break;
+              case 'overlayClose':
+                element.attr('overlay-close', config[prop]);
+                break;
               default:
                 element.attr(prop, config[prop]);
             }

--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -159,7 +159,8 @@
         'animationIn',
         'animationOut',
         'overlay',
-        'overlayClose'
+        'overlayClose',
+        'class'
       ];
 
       if(config.templateUrl) {


### PR DESCRIPTION
This adds another case to property handling in ModalFactory. 

Using white-listed config property "overlayClose" with ModalFactory did not work, because the attribute was rendered as-is (camelCase), thus getting ignored during compilation of the directive element.
Unfortunately we cannot use attrs.$normalize() in ModuleFactory because we're outside the directive and link() function.