### PR TITLE
Allow ModalFactory to create dialog modals

### DIFF
--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -20,6 +20,7 @@
     .controller('NavController', NavController)
     .controller('AngularModsController', AngularModsController)
     .controller('IconicController', IconicController)
+    .controller('ModalController', ModalController)
   ;
 
   config.$inject = ['$urlRouterProvider', '$locationProvider'];
@@ -293,6 +294,28 @@
       $timeout(function() {
         $scope.delayLoadedIcon = icons[0];
       });
+    }
+  }
+  
+  ModalController.$inject = ['$scope', '$timeout', 'ModalFactory'];
+
+  function ModalController($scope, $timeout, ModalFactory) {
+    $scope.createModal = function() {
+      var modal = new ModalFactory({
+        class: 'tiny dialog',
+        overlay: true,
+        overlayClose: false,
+        templateUrl: 'partials/examples-dynamic-modal.html',
+        contentScope: {
+          close: function() {
+            modal.deactivate();
+            $timeout(function() {
+              modal.destroy();
+            }, 1000);
+          }
+        }
+      });
+      modal.activate();
     };
   }
 

--- a/docs/partials/examples-dynamic-modal.html
+++ b/docs/partials/examples-dynamic-modal.html
@@ -1,0 +1,8 @@
+<div class="grid-block vertical text-center">
+  <div class="grid-content">
+    <strong>This modal was created programmatically</strong>
+    <br/>
+    <br/>
+    <a class="button" ng-click="close()">Close</a>
+  </div>
+</div>

--- a/docs/templates/modal.html
+++ b/docs/templates/modal.html
@@ -2,6 +2,7 @@
 name: modal
 url: /modal
 title: Modal
+controller: ModalController
 ---
 
 <h2>Modal</h2>
@@ -123,6 +124,37 @@ title: Modal
     <a zf-open="dialogModal" class="button">Itty-Bitty Modal</a>
   </div>
 </div>
+
+<hr>
+
+<h3>Programmatic Modals</h3>
+
+<p>Modals can be created on the fly using our <code>ModalFactory</code>.  Clicking the button will execute the code shown below.</p>
+
+<div class="grid-content text-center">
+  <a class="button" ng-click="createModal()">Open modal</a>
+</div>
+<div class="grid-content">
+<hljs language="javascript">
+  var modal = new ModalFactory({
+    class: 'tiny dialog',
+    overlay: true,
+    overlayClose: false,
+    templateUrl: 'partials/examples-dynamic-modal.html',
+    contentScope: {
+      close: function() {
+        modal.deactivate();
+        $timeout(function() {
+          modal.destroy();
+        }, 1000);
+      }
+    }
+  });
+  modal.activate();
+</hljs>
+</div>
+
+<p>As you can see, the modal was specified to be a tiny dialog by setting the required classes for the <code>class</code> property of the config object passed to the <code>ModalFactory</code>.  The class property also supports arrays, if you wish to use <code>class: ['tiny', 'dialog']</code> instead.</p>
 
 <hr>
 

--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -268,6 +268,7 @@
                 break;
               case 'overlayClose':
                 element.attr('overlay-close', config[prop] ? 'true' : 'false'); // must be string, see postLink() above
+                break;
               case 'class':
                 if (angular.isString(config[prop])) {
                   config[prop].split(' ').forEach(function(klass) {
@@ -281,6 +282,7 @@
                 break;
               default:
                 element.attr(prop, config[prop]);
+                break;
             }
           }
         }

--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -237,7 +237,7 @@
 
             attached = true;
           }
-          
+
           scope.active = state;
         });
       }
@@ -254,7 +254,7 @@
 
         scope = $rootScope.$new();
 
-        // account for directive attributes
+        // account for directive attributes and modal classes
         for(var i = 0; i < props.length; i++) {
           var prop = props[i];
 
@@ -268,6 +268,16 @@
                 break;
               case 'overlayClose':
                 element.attr('overlay-close', config[prop] ? 'true' : 'false'); // must be string, see postLink() above
+              case 'class':
+                if (angular.isString(config[prop])) {
+                  config[prop].split(' ').forEach(function(klass) {
+                    element.addClass(klass);
+                  });
+                } else if (angular.isArray(config[prop])) {
+                  config[prop].forEach(function(klass) {
+                    element.addClass(klass);
+                  });
+                }
                 break;
               default:
                 element.attr(prop, config[prop]);

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -73,386 +73,388 @@ $meter-radius: 0 !default;
      -moz-appearance: none;
 }
 
-// Text fields
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-#{$text-input-selectors} {
-  $top-padding: get-side($form-padding, top);
-  $bottom-padding: get-side($form-padding, bottom);
-  $height: ($form-fontsize * 1.4) + $top-padding + $bottom-padding;
+@include exports(forms) {
+  // Text fields
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  #{$text-input-selectors} {
+    $top-padding: get-side($form-padding, top);
+    $bottom-padding: get-side($form-padding, bottom);
+    $height: ($form-fontsize * 1.4) + $top-padding + $bottom-padding;
 
-  @include no-appearance;
-  display: block;
-  width: 100%;
-  height: $height;
-  padding: $form-padding;
-  margin: 0 0 $global-padding 0;
-  border: $input-border;
-  border-radius: 0;
-  background: $input-background;
-  color: $input-color;
-  font-size: $form-fontsize;
-  -webkit-font-smoothing: antialiased;
-  vertical-align: middle;
-
-  &:hover {
-    border: $input-border-hover;
-    background: $input-background-hover;
-    color: $input-color-hover;
-  }
-  &:focus {
-    outline: 0;
-    border: $input-border-focus;
-    background: $input-background-focus;
-    color: $input-color-focus;
-  }
-
-  label > & {
-    margin-top: $form-label-margin;
-  }
-}
-
-// Override the content-box declaration set by Normalize
-input[type="search"] {
-  box-sizing: border-box;
-}
-
-// Disabled state
-input, textarea {
-  &.disabled,
-  &[disabled],
-  &[readonly],
-  fieldset[disabled] & {
-    cursor: $input-cursor-disabled;
-
-    &, &:hover {
-      background-color: $input-background-disabled;
-    }
-  }
-}
-
-// Labels
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-label {
-  display: block;
-  font-size: $form-label-fontsize;
-  margin-bottom: $form-label-margin;
-  color: $form-label-color;
-
-  > input, > textarea {
-    margin-top: $form-label-margin;
-  }
-}
-
-// Checkbox/radio buttons
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-input[type="checkbox"], input[type="radio"] {
-  width: 1rem;
-  height: 1rem;
-
-  // Input inside of a label
-  label > & {
-    margin-right: $form-padding * 0.5;
-  }
-
-  // Input next to a label
-  & + label {
-    display: inline-block;
-    margin-left: $form-padding;
-    margin-right: $form-padding * 2;
-    margin-bottom: 0;
-    vertical-align: baseline;
-  }
-}
-
-// Inline labels
-// Inline labels allow you to prefix or postfix special labels to inputs
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-.inline-label {
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: stretch;
-  margin-bottom: $global-padding;
-
-  // Imitates the top margin on normal inputs
-  label > & {
-    margin-top: $form-label-margin;
-  }
-
-  // Inputs stretch all the way out
-  > input, > select {
-    flex: 1;
-    margin: 0;
-  }
-
-  // Inline labels and buttons shrink
-  > .form-label {
-    flex: 0 0 auto;
-    background: $inlinelabel-background;
-    color: $inlinelabel-color;
-    border: $inlinelabel-border;
-    padding: 0 $form-padding;
-    display: flex;
-    align-items: center;
-
-    &:first-child { border-right: 0; }
-    &:last-child  { border-left: 0; }
-  }
-  // Buttons also shrink
-  > a,
-  > button,
-  > input[type="button"],
-  > input[type="submit"] {
-    flex: 0 0 auto;
-    display: flex;
-    align-items: center;
-    padding-top: 0;
-    padding-bottom: 0;
-    margin: 0;
+    @include no-appearance;
+    display: block;
+    width: 100%;
+    height: $height;
+    padding: $form-padding;
+    margin: 0 0 $global-padding 0;
+    border: $input-border;
     border-radius: 0;
-  }
-}
+    background: $input-background;
+    color: $input-color;
+    font-size: $form-fontsize;
+    -webkit-font-smoothing: antialiased;
+    vertical-align: middle;
 
-// Text areas
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-textarea {
-  height: auto;
-  width: 100%;
-  min-height: 50px;
-}
-
-// Select menus
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-select {
-  $top-padding: get-side($form-padding, top);
-  $bottom-padding: get-side($form-padding, bottom);
-  $height: ($form-fontsize * 1.4) + $top-padding + $bottom-padding;
-  $color: isitlight($select-background);
-
-  @include no-appearance;
-  display: block;
-  width: 100%;
-  height: $height;
-  padding: $form-padding;
-  margin: 0 0 $global-padding 0;
-  font-size: $form-fontsize;
-  color: $select-color;
-  border-radius: 0;
-  border: $input-border;
-
-  @if $select-arrow {
-    background: $select-background url(image-triangle($select-arrow-color)) right 10px center no-repeat;
-    background-size: 8px 8px;
-    padding-right: rem-calc(18px) + $form-padding;
-  }
-  @else {
-    background-color: $select-background
-  }
-
-  &:hover {
-    background-color: $select-background-hover;
-  }
-
-  &:focus {
-    outline: 0;
-  }
-
-  // Remove the dropdown arrow added in IE10/11
-  &::-ms-expand {
-    display: none;
-  }
-}
-
-// Range slider
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-input[type="range"] {
-  $margin: ($slider-thumb-height - $slider-height) / 2;
-
-  @include no-appearance;
-  display: block;
-  width: 100%;
-  height: auto;
-  cursor: pointer;
-  margin-top: $margin;
-  margin-bottom: $margin;
-  border: 0;
-  line-height: 1;
-
-  @if hasvalue($slider-radius) {
-    border-radius: $slider-radius;
-  }
-
-  &:focus {
-    outline: 0;
-  }
-
-  // Chrome/Safari
-  &::-webkit-slider-runnable-track {
-    height: $slider-height;
-    background: $slider-background;
-  }
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    background: $slider-thumb-color;
-    width: $slider-thumb-height;
-    height: $slider-thumb-height;
-    margin-top: -$margin;
-    @if hasvalue($slider-thumb-radius) {
-      border-radius: $slider-thumb-radius;
+    &:hover {
+      border: $input-border-hover;
+      background: $input-background-hover;
+      color: $input-color-hover;
     }
-  }
-  // Firefox
-  &::-moz-range-track {
-    -moz-appearance: none;
-    height: $slider-height;
-    background: #ccc;
-  }
-  &::-moz-range-thumb {
-    -moz-appearance: none;
-    background: $slider-thumb-color;
-    width: $slider-thumb-height;
-    height: $slider-thumb-height;
-    margin-top: -$margin;
-    @if hasvalue($slider-thumb-radius) {
-      border-radius: $slider-thumb-radius;
+    &:focus {
+      outline: 0;
+      border: $input-border-focus;
+      background: $input-background-focus;
+      color: $input-color-focus;
     }
-  }
-  // Internet Explorer
-  &::-ms-track {
-    height: $slider-height;
-    background: $slider-background;
-    color: transparent;
-    border: 0;
-    overflow: visible;
-    border-top: $margin solid $body-background;
-    border-bottom: $margin solid $body-background;
-  }
-  &::-ms-thumb {
-    background: $slider-thumb-color;
-    width: $slider-thumb-height;
-    height: $slider-thumb-height;
-    border: 0;
-    @if hasvalue($slider-thumb-radius) {
-      border-radius: $slider-thumb-radius;
-    }
-  }
-  &::-ms-fill-lower, &::-ms-fill-upper {
-    background: $slider-background;
-  }
-}
-output {
-  line-height: $slider-thumb-height;
-  vertical-align: middle;
-  margin-left: 0.5em;
-}
 
-// Number inputs
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-input[type="number"] {
-  &::-webkit-inner-spin-button {
-
-  }
-  &::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    background: $primary-color;
-  }
-}
-
-// Progress and meter
-// - - - - - - - - - - - - - - - - - - - - - - - - -
-progress, meter {
-  @include no-appearance;
-  display: block;
-  width: 100%;
-  height: $meter-height;
-  margin-bottom: 1rem;
-
-  @if hasvalue($meter-radius) {
-    border-radius: $meter-radius;
-  }
-
-  // For Firefox
-  background: $meter-background;
-  border: 0;
-}
-
-progress {
-  &::-webkit-progress-bar {
-    background: $meter-background;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-webkit-progress-value {
-    background: $meter-fill;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-moz-progress-bar {
-    background: $meter-fill;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
+    label > & {
+      margin-top: $form-label-margin;
     }
   }
 
-  @each $name, $color in (high: $meter-fill-high, medium: $meter-fill-medium, low: $meter-fill-low) {
-    &.#{$name} {
-      &::-webkit-progress-value {
-        background: $color;
-      }
-      &::-moz-progress-bar {
-        background: $color;
+  // Override the content-box declaration set by Normalize
+  input[type="search"] {
+    box-sizing: border-box;
+  }
+
+  // Disabled state
+  input, textarea {
+    &.disabled,
+    &[disabled],
+    &[readonly],
+    fieldset[disabled] & {
+      cursor: $input-cursor-disabled;
+
+      &, &:hover {
+        background-color: $input-background-disabled;
       }
     }
   }
-}
-meter {
-  // Chrome/Safari
-  &::-webkit-meter-bar {
-    background: $meter-background;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-webkit-meter-inner-element {
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-webkit-meter-optimum-value {
-    background: $meter-fill-high;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-webkit-meter-suboptimum-value {
-    background: $meter-fill-medium;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
-    }
-  }
-  &::-webkit-meter-even-less-good-value {
-    background: $meter-fill-low;
-    @if hasvalue($meter-radius) {
-      border-radius: $meter-radius;
+
+  // Labels
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  label {
+    display: block;
+    font-size: $form-label-fontsize;
+    margin-bottom: $form-label-margin;
+    color: $form-label-color;
+
+    > input, > textarea {
+      margin-top: $form-label-margin;
     }
   }
 
-  // Firefox
-  background: $meter-background;
-  &::-moz-meter-bar {
-    background: $primary-color;
+  // Checkbox/radio buttons
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  input[type="checkbox"], input[type="radio"] {
+    width: 1rem;
+    height: 1rem;
+
+    // Input inside of a label
+    label > & {
+      margin-right: $form-padding * 0.5;
+    }
+
+    // Input next to a label
+    & + label {
+      display: inline-block;
+      margin-left: $form-padding;
+      margin-right: $form-padding * 2;
+      margin-bottom: 0;
+      vertical-align: baseline;
+    }
+  }
+
+  // Inline labels
+  // Inline labels allow you to prefix or postfix special labels to inputs
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  .inline-label {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: stretch;
+    margin-bottom: $global-padding;
+
+    // Imitates the top margin on normal inputs
+    label > & {
+      margin-top: $form-label-margin;
+    }
+
+    // Inputs stretch all the way out
+    > input, > select {
+      flex: 1;
+      margin: 0;
+    }
+
+    // Inline labels and buttons shrink
+    > .form-label {
+      flex: 0 0 auto;
+      background: $inlinelabel-background;
+      color: $inlinelabel-color;
+      border: $inlinelabel-border;
+      padding: 0 $form-padding;
+      display: flex;
+      align-items: center;
+
+      &:first-child { border-right: 0; }
+      &:last-child  { border-left: 0; }
+    }
+    // Buttons also shrink
+    > a,
+    > button,
+    > input[type="button"],
+    > input[type="submit"] {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      padding-top: 0;
+      padding-bottom: 0;
+      margin: 0;
+      border-radius: 0;
+    }
+  }
+
+  // Text areas
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  textarea {
+    height: auto;
+    width: 100%;
+    min-height: 50px;
+  }
+
+  // Select menus
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  select {
+    $top-padding: get-side($form-padding, top);
+    $bottom-padding: get-side($form-padding, bottom);
+    $height: ($form-fontsize * 1.4) + $top-padding + $bottom-padding;
+    $color: isitlight($select-background);
+
+    @include no-appearance;
+    display: block;
+    width: 100%;
+    height: $height;
+    padding: $form-padding;
+    margin: 0 0 $global-padding 0;
+    font-size: $form-fontsize;
+    color: $select-color;
+    border-radius: 0;
+    border: $input-border;
+
+    @if $select-arrow {
+      background: $select-background url(image-triangle($select-arrow-color)) right 10px center no-repeat;
+      background-size: 8px 8px;
+      padding-right: rem-calc(18px) + $form-padding;
+    }
+    @else {
+      background-color: $select-background
+    }
+
+    &:hover {
+      background-color: $select-background-hover;
+    }
+
+    &:focus {
+      outline: 0;
+    }
+
+    // Remove the dropdown arrow added in IE10/11
+    &::-ms-expand {
+      display: none;
+    }
+  }
+
+  // Range slider
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  input[type="range"] {
+    $margin: ($slider-thumb-height - $slider-height) / 2;
+
+    @include no-appearance;
+    display: block;
+    width: 100%;
+    height: auto;
+    cursor: pointer;
+    margin-top: $margin;
+    margin-bottom: $margin;
+    border: 0;
+    line-height: 1;
+
+    @if hasvalue($slider-radius) {
+      border-radius: $slider-radius;
+    }
+
+    &:focus {
+      outline: 0;
+    }
+
+    // Chrome/Safari
+    &::-webkit-slider-runnable-track {
+      height: $slider-height;
+      background: $slider-background;
+    }
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      background: $slider-thumb-color;
+      width: $slider-thumb-height;
+      height: $slider-thumb-height;
+      margin-top: -$margin;
+      @if hasvalue($slider-thumb-radius) {
+        border-radius: $slider-thumb-radius;
+      }
+    }
+    // Firefox
+    &::-moz-range-track {
+      -moz-appearance: none;
+      height: $slider-height;
+      background: #ccc;
+    }
+    &::-moz-range-thumb {
+      -moz-appearance: none;
+      background: $slider-thumb-color;
+      width: $slider-thumb-height;
+      height: $slider-thumb-height;
+      margin-top: -$margin;
+      @if hasvalue($slider-thumb-radius) {
+        border-radius: $slider-thumb-radius;
+      }
+    }
+    // Internet Explorer
+    &::-ms-track {
+      height: $slider-height;
+      background: $slider-background;
+      color: transparent;
+      border: 0;
+      overflow: visible;
+      border-top: $margin solid $body-background;
+      border-bottom: $margin solid $body-background;
+    }
+    &::-ms-thumb {
+      background: $slider-thumb-color;
+      width: $slider-thumb-height;
+      height: $slider-thumb-height;
+      border: 0;
+      @if hasvalue($slider-thumb-radius) {
+        border-radius: $slider-thumb-radius;
+      }
+    }
+    &::-ms-fill-lower, &::-ms-fill-upper {
+      background: $slider-background;
+    }
+  }
+  output {
+    line-height: $slider-thumb-height;
+    vertical-align: middle;
+    margin-left: 0.5em;
+  }
+
+  // Number inputs
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  input[type="number"] {
+    &::-webkit-inner-spin-button {
+
+    }
+    &::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      background: $primary-color;
+    }
+  }
+
+  // Progress and meter
+  // - - - - - - - - - - - - - - - - - - - - - - - - -
+  progress, meter {
+    @include no-appearance;
+    display: block;
+    width: 100%;
+    height: $meter-height;
+    margin-bottom: 1rem;
+
     @if hasvalue($meter-radius) {
       border-radius: $meter-radius;
     }
+
+    // For Firefox
+    background: $meter-background;
+    border: 0;
   }
-  &:-moz-meter-optimum::-moz-meter-bar {
-    background: $meter-fill-high;
+
+  progress {
+    &::-webkit-progress-bar {
+      background: $meter-background;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-webkit-progress-value {
+      background: $meter-fill;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-moz-progress-bar {
+      background: $meter-fill;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    @each $name, $color in (high: $meter-fill-high, medium: $meter-fill-medium, low: $meter-fill-low) {
+      &.#{$name} {
+        &::-webkit-progress-value {
+          background: $color;
+        }
+        &::-moz-progress-bar {
+          background: $color;
+        }
+      }
+    }
   }
-  &:-moz-meter-sub-optimum::-moz-meter-bar {
-    background: $meter-fill-medium;
-  }
-  &:-moz-meter-sub-sub-optimum::-moz-meter-bar {
-    background: $meter-fill-low;
+  meter {
+    // Chrome/Safari
+    &::-webkit-meter-bar {
+      background: $meter-background;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-webkit-meter-inner-element {
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-webkit-meter-optimum-value {
+      background: $meter-fill-high;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-webkit-meter-suboptimum-value {
+      background: $meter-fill-medium;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &::-webkit-meter-even-less-good-value {
+      background: $meter-fill-low;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    // Firefox
+    background: $meter-background;
+    &::-moz-meter-bar {
+      background: $primary-color;
+      @if hasvalue($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+    &:-moz-meter-optimum::-moz-meter-bar {
+      background: $meter-fill-high;
+    }
+    &:-moz-meter-sub-optimum::-moz-meter-bar {
+      background: $meter-fill-medium;
+    }
+    &:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+      background: $meter-fill-low;
+    }
   }
 }


### PR DESCRIPTION
Extend ModalFactory configuration to allow creation of dialog modals by
adding dialog class to dynamically generated element.  This change allows creating a dialog modal via the ModalFactory by providing the following configuration:
```js
var modal = new ModalFactory({
  dialog: true,
  ...
});
```
This PR and #561 should be reviewed together as they both deal with adding classes to the generated modal.  This PR is specific to allowing the **dialog** class to be added, while the other is generic and allows any class to be added.