### PR TITLE
Fix vh calculation in Mobile Safari

### DIFF
--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -43,7 +43,12 @@
       var ua = navigator.userAgent;
 
       if (ua.match(/iP(hone|ad|od)/) && !ua.match(/CriOS/)) {
-        document.body.classList.add('is-mobilesafari');
+        if (ua.match(/i(Phone|od)/)) {
+          document.body.classList.add('is-iphone');
+        }
+        else {
+          document.body.classList.add('is-ipad');
+        }
       }
   }
 

--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -42,7 +42,11 @@
 
       var ua = navigator.userAgent;
 
-      if (ua.match(/iP(hone|ad|od)/) && !ua.match(/CriOS/)) {
+      // Add special classes for Mobile Safari to correct its miscalculation of 100vh
+      // The first check is to see if it's an Apple device
+      // The second check is to make sure it's not a UIWebView
+      // The third check is to make sure it's not Chrome for iOS
+      if (ua.match(/iP(hone|ad|od)/) && ua.match(/Safari/) && !ua.match(/CriOS/)) {
         if (ua.match(/i(Phone|od)/)) {
           document.body.classList.add('is-iphone');
         }

--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -39,6 +39,12 @@
 
   function run() {
       FastClick.attach(document.body);
+
+      var ua = navigator.userAgent;
+
+      if (ua.match(/iP(hone|ad|od)/) && !ua.match(/CriOS/)) {
+        document.body.classList.add('is-mobilesafari');
+      }
   }
 
   track.$inject = ['$rootScope','$window', '$location'];

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -74,8 +74,10 @@ $foundation-colors: (
   // Make extra sure we're using the whole window
   html, body {
     height: 100%;
+    overflow: hidden;
     font-size: $base-font-size;
   }
+  
   // Set box-sizing globally to handle padding and border widths
   html {
     box-sizing: border-box;
@@ -114,7 +116,11 @@ $foundation-colors: (
   }
 
   // Give all anchors and interactive directives the hover cusor
-  a, [ui-sref], [zf-open], [zf-close], [zf-toggle] {
+  a,
+  [ui-sref],
+  [zf-open],
+  [zf-close],
+  [zf-toggle] {
     cursor: pointer;
   }
 

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -225,8 +225,13 @@ $block-grid-max-size: 6 !default;
   backface-visibility: hidden;
 
   // Correct vh in Mobile Safari
-  .is-mobilesafari & {
+  // Srs, this is the worst
+  .is-iphone & {
     height: calc(100vh - 69px);
+  }
+
+  .is-ipad & {
+    height: calc(100vh - 24px);
   }
 
   @include grid-size($size);

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -224,6 +224,11 @@ $block-grid-max-size: 6 !default;
   overflow: hidden;
   backface-visibility: hidden;
 
+  // Correct vh in Mobile Safari
+  .is-mobilesafari & {
+    height: calc(100vh - 69px);
+  }
+
   @include grid-size($size);
   @include grid-orient($orientation);
   @include grid-wrap($wrap);


### PR DESCRIPTION
This is an initial test to correct Mobile Safari's incorrect calculation of `vh`. With the magic of user agent sniffing, we can override the default height of the grid frame.

```css
/* This is the worst, right? */
.is-iphone .grid-frame {
  height: calc(100vh - 69px);
}

.is-ipad .grid-frame {
  height: calc(100vh - 24px);
}
```

If you compile the docs on this branch, you'll see that the entire chrome of the app is visible, and the app never shifts to the minimal UI mode.

We're specifically targeting Mobile Safari, *not* Chrome for iOS, which doesn't have these issues. ~~Come to think of it, I'm not sure how this affects apps viewed in an in-app browser. Might need to look into that.~~ Never mind, figured that out!

To be extra safe, I also added `overflow: hidden` to the `<html>` and `<body>` elements, which is fine because apps written in F4A never scroll the body. If possible I'd like to also prevent Mobile Safari from rubber banding the window when the user scrolls.