### PR TITLE
IE10 11 select arrow svg fix

### DIFF
--- a/scss/helpers/_images.scss
+++ b/scss/helpers/_images.scss
@@ -1,6 +1,6 @@
 @function image-triangle($color: #000) {
   $color: rgb(red($color), green($color), blue($color));
-  @return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="32" height="24" viewBox="0 0 32 24"><polygon points="0,0 32,0 16,24" style="fill: #{$color}"></polygon></svg>';
+  @return "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20version%3D%221.1%22%20width%3D%2232%22%20height%3D%2224%22%20viewBox%3D%220%200%2032%2024%22%3E%3Cpolygon%20points%3D%220%2C0%2032%2C0%2016%2C24%22%20style%3D%22fill%3A%20#{$color}%22%3E%3C/polygon%3E%3C/svg%3E";
 }
 
 @mixin image-checkmark($color: #000) {


### PR DESCRIPTION
Windows 7 64 
IE 11
![ie11_select](https://cloud.githubusercontent.com/assets/9974302/7468693/5402c582-f314-11e4-8ef8-15e1176166e1.PNG)
IE 11 applied fix
![ie11_select_fix_applied](https://cloud.githubusercontent.com/assets/9974302/7468692/540211e6-f314-11e4-8bf2-6d7c9a03bf7f.PNG)

also works in other browsers, on mobile too, I didn't test on Safari 7+ (not a mac user)

here a nice convertor http://codepen.io/yoksel/details/JDqvs/ thanks to the creator

the code sure doesn't look nice but is compatible with all browsers including IE10 and 11