### PR TITLE
Fix stylesheet portion of bower.json to comply w/ new `main` spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "foundation-apps",
   "version": "1.1.0",
   "main": [
-    "dist/css/foundation-apps.css",
+    "scss/foundation.scss",
     "dist/js/foundation-apps.js",
     "dist/js/foundation-apps-templates.js"
   ],


### PR DESCRIPTION
Per https://github.com/bower/bower.json-spec/pull/43 / https://github.com/bower/bower.json-spec/commit/0b34d2bb0bdd4fa31fa9728f787f49e170e41f99, which has finally brought clarity regarding `main`. In particular:
> * Use source files with module exports and imports over pre-built distribution files.

Also, in the spec's example, the CSS files aren't included in `main`, but the main SCSS file is.