### PR TITLE
Typo in dialogModal code column

### DIFF
--- a/docs/templates/modal.html
+++ b/docs/templates/modal.html
@@ -111,7 +111,7 @@ controller: ModalController
 <div class="grid-block">
   <div class="small-12 medium-6 grid-content">
 <hljs>
-<a zf-open="animatedModal" class="button">Itty-Bitty Modal</a>
+<a zf-open="dialogModal" class="button">Itty-Bitty Modal</a>
 
 <div zf-modal id="dialogModal" overlay="false" overlay-close="false" class="tiny dialog">
   <h4>Yo, do you <em>really</em> want to do this?</h4>


### PR DESCRIPTION
The dialog modal code section said zf-open="animatedModal" instead of dialogModal