### PR TITLE
fix modal close issues

### DIFF
--- a/js/angular/components/modal/modal.js
+++ b/js/angular/components/modal/modal.js
@@ -308,11 +308,11 @@
 
       function destroy() {
         self.deactivate();
-        setTimeout(function() {
+        $timeout(function() {
           scope.$destroy();
           element.remove();
           destroyed = true;
-        }, 3000);
+        }, 0, false);
         foundationApi.unsubscribe(id);
       }
 


### PR DESCRIPTION
The issue with modal close (including scope and element variables sometimes being undefined as noted in soumak77's pr) seems to be stemming from the use of setTimeout instead of $timeout. Using $timeout also appears to eliminate the need for a 3 second delay which was also causing errors when trying to destroy modals immediately before redrawing them which appears necessary when changing the content scope of programmatically created modals using ModalFactory directly.