### PR TITLE
Correct notification mixin name in documentation

### DIFF
--- a/docs/templates/notification.html
+++ b/docs/templates/notification.html
@@ -121,7 +121,7 @@ foundationApi.publish('main-notifications', { title: 'Test', content: 'Test2' })
   );
 
   // Use the style mixin to style the notification
-  @include notification-layout(
+  @include notification-style(
     $background: #fff, // Background color
     $color: #000, // Text color
     $padding: 1rem,


### PR DESCRIPTION
I tried to customize notifications as suggested in documentation and I notice an error in mixin name.
[`here`](http://foundation.zurb.com/apps/docs/#!/notification) in Sass Mixins section
```notification-layout -> notification-style```
cheers