### PR TITLE
deps: version bump on angular libs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,9 +9,9 @@
     "viewport-units-buggyfill": "~0.4.1",
     "tether": "~0.6.5",
     "fastclick": "~1.0.6",
-    "angular": "~1.3.4",
+    "angular": "~1.4.7",
     "angular-ui-router": "~0.2.12",
-    "angular-animate": "~1.3.4",
+    "angular-animate": "~1.4.7",
     "hammerjs": "~2.0.4"
   },
   "homepage": "https://github.com/zurb/foundation-apps",
@@ -38,8 +38,8 @@
     "scss/_includes.scss"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.3.4",
-    "angular-highlightjs": "~0.3.2",
+    "angular-mocks": "~1.4.7",
+    "angular-highlightjs": "~0.4.3",
     "allmighty-autocomplete": "*",
     "marked": "~0.3.2",
     "jsdiff": "~1.0.8",


### PR DESCRIPTION
based on conversations in https://github.com/zurb/foundation-apps/issues/694#issuecomment-149650049. bumping to to a lower bound of 1.4.7 doesn't have any issues.

Closes #694