### PR TITLE
Add button[disabled] attribute styles

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -194,7 +194,7 @@ $button-tag-selector: false !default;
       }
     }
 
-    &.disabled { @include button-disabled; }
+    &.disabled, &[disabled] { @include button-disabled; }
   }
 
   @if $button-tag-selector {


### PR DESCRIPTION
Because there are differences between adding a `disabled` class and actually disabling a button. The current workaround is to add the attribute AND the class to the button element.

For comparison, [the "plain old" Foundation library has styles for button[disabled]](https://github.com/zurb/foundation/blob/master/scss/foundation/components/_buttons.scss#L242).