### PR TITLE
Applied fix for depciation warning

### DIFF
--- a/scss/components/_modal.scss
+++ b/scss/components/_modal.scss
@@ -67,7 +67,7 @@ $modal-overlay-background: rgba(#333, 0.7) !default;
   @if $border != 0 {
     border: $border;
   }
-  @if $radius != 0 {
+  @if $radius != 0px {
     border-radius: $radius;
   }
   @if $shadow != none {


### PR DESCRIPTION
During compiling of SCSS kept getting a warning

> The result of `0px != 0` will be `true` in future releases of Sass.
> Unitless numbers will no longer be equal to the same numbers with units.