### PR TITLE
Update ModalFactory docs

### DIFF
--- a/docs/templates/modal.html
+++ b/docs/templates/modal.html
@@ -137,10 +137,10 @@ var modal = new ModalFactory({
   // Add CSS classes to the modal
   // Can be a single string or an array of classes
   class: 'tiny dialog',
-  // Set if the modal has a background overlay
-  overlay: true,
-  // Set if the modal can be closed by clicking on the overlay
-  overlayClose: false,
+  // Set if the modal has a background overlay. Must be string
+  overlay: 'true',
+  // Set if the modal can be closed by clicking on the overlay. Must be string
+  overlayClose: 'false',
   // Define a template to use for the modal
   templateUrl: 'partials/examples-dynamic-modal.html',
   // Allows you to pass in properties to the scope of the modal


### PR DESCRIPTION
ModalFactory expects to find overlay === 'false' to actually  set it to false and it also expects overlayClose to be a string to properly set the value. So I made a small change in the example  to reflect this behavior.