### PR TITLE
adding gutter class to grid blocks

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -235,6 +235,7 @@
 
 // $container-width: rem-calc(900);
 // $block-padding: $global-padding;
+// $block-spacing: $global-spacing;
 // $total-columns: 12;
 // $block-grid-max-size: 6; 
 

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -14,11 +14,11 @@
    - Source ordering
    - Offsets
 */
-
 /// @Foundation.settings
 // Grid
 $container-width: rem-calc(900) !default;
 $block-padding: $global-padding !default;
+$block-spacing: $global-spacing !default;
 $total-columns: 12 !default;
 $block-grid-max-size: 6 !default;
 ///
@@ -30,19 +30,35 @@ $block-grid-max-size: 6 !default;
 
   If set to a number, the block will be given a percentage width, based on the total number of columns (12 by default). Percentage widths don't work if a block is inside a vertical grid.
 
+  If $gutter-width set to a number that is not "0", grid blocks will have "justify-content: space-between" like flex styles with a fixed space. 
+  
   @group grid
 
   @param {number|string} $size - Sizing behavior of the block. Should be expand, shrink, or a number.
 
+  @param {number} $gutter-width - Size of fixed gutter to be added.
+
   @output The flex-basis, flex-grow, and flex-shrink properties.
 */
-@mixin grid-size($size: expand) {
-  @if (type-of($size) == 'number') {
+@mixin grid-size($size: expand, $gutter-width: 0) {
+
+  @if (type-of($size) == 'number' and strip-unit($gutter-width) != 0) {
     $pct: percentage($size / $total-columns);
+
+    // use calc to gutters between relative columns 
+    flex: 0 0 calc(#{$pct} - #{$gutter-width});
+    // max-width prevents columns from wrapping early in IE10/11
+    max-width: calc(#{$pct} - #{$gutter-width});
+  }
+
+  @else if (type-of($size) == 'number') {
+    $pct: percentage($size / $total-columns);
+
     flex: 0 0 $pct;
     // max-width prevents columns from wrapping early in IE10/11
     max-width: $pct;
   }
+
   @else if ($size == shrink) {
     flex: 0 0 auto;
     overflow: visible;
@@ -50,7 +66,9 @@ $block-grid-max-size: 6 !default;
   @else if ($size == expand) {
     flex: 1 1 auto;
   }
+
 }
+
 /*
   Set the orientation of blocks within this block. The grid is re-oriented by changing the flex direction of the block.
 
@@ -284,7 +302,7 @@ $block-grid-max-size: 6 !default;
 // - - - - - - - - - - - - - - - - - - - -
 
 // Shared styles for frames and blocks (parent elements)
-%block-core {
+%block-core {  
   // Change the direction children flow
   &.vertical { @include grid-orient(vertical); }
   @each $size in $breakpoint-classes {
@@ -301,7 +319,16 @@ $block-grid-max-size: 6 !default;
   &.align-spaced  { @include grid-align(spaced); }
 
   // Allow child elements to wrap
-  &.wrap { @include grid-wrap(true); }
+  &.wrap { 
+    @include grid-wrap(true); 
+  }
+
+  // Allow for gutters
+  // Set negative margins on parent block to crop gutters of direct children
+  &.gutters {
+    margin: -($block-spacing/2);
+  }
+
 }
 
 // Shared styles for blocks and content blocks (child elements)
@@ -311,6 +338,12 @@ $block-grid-max-size: 6 !default;
 
   // Prevent an element from scrolling
   &.noscroll { overflow: visible; }
+
+  // Add gutters to child blocks
+  .gutters > & {
+    margin: $block-spacing/2;
+  }
+
 }
 
 @include exports(grid) {
@@ -396,6 +429,10 @@ $block-grid-max-size: 6 !default;
         // Block sizing
         .#{$size}-#{$i} {
           @include grid-size($i);
+          // Block sizing with gutters
+          .gutters > & {
+            @include grid-size($i,$block-spacing);
+          }
         }
         // Source ordering
         .#{$size}-order-#{$i} {


### PR DESCRIPTION
Adding `.gutters` class to `grid-block` so that you can apply spacing between columns for easier styling of `background` related styles. One of the benefits of flex is to have fixed height columns, but currently when using the Manual sizing grid there is no way to allow for gutters so you have to nest elements which impedes the ability to have full (`stretch`) height flex blocks/items. 

This will work for both manual and default flex grid and use the `$global-spacing` variable as `!default`.

When using `.wrap` ideally the `align-items` should be set to `stretch` and not `flex-start`, but I will manage that locally and submit as a separate request as I think it should be `.wrap` with full height stretch should be supported regardless if the `gutters` class adopted. 

### Practical Examples
_Custom `.scss` to be shared by all practical examples below_
````SCSS
.bg-fill-color {
    background-color: cyan;
}
.wrap {
    &.grid-block {
        &.gutters {
            align-items: stretch; // override `flex-start`
        }
    }
}
````

**Flex grid**
````HTML
<div class="grid-block gutters">
  <div class="shrink grid-block bg-fill-color">Hello</div>
  <div class="grid-block bg-fill-color">World</div>
</div>
````
**Manual Sizing grid**
````HTML
<div class="grid-block gutters">
  <div class="grid-block small-6 medium-4 bg-fill-color">Hello</div>
  <div class="grid-block small-6 medium-8 bg-fill-color">World</div>
</div>
````
**Manual Sizing grid with wrap** 
Note: should use temp `.scss` shiv for `wrap` above
````HTML
<div class="grid-block gutters wrap">
  <div class="grid-block small-12 medium-4 bg-fill-color">Hello</div>
  <div class="grid-block small-6 medium-8 bg-fill-color">Around</div>
  <div class="grid-block small-6 medium-6 bg-fill-color">the</div>
  <div class="grid-block small-12 medium-6 bg-fill-color">World</div>
</div>
````

### Docs (does not show cleary with current documentation style treatment)

````HTML
<h4>Gutters</h4>

<p>Use `gutters` class on your `grid-block` to apply `$global-spacing` to your columns. This can help with styling background fills of your blocks that will strech the full height.</p>

<hljs language="html">
<div class="grid-block gutters">
  <div class="shrink grid-block"></div>
  <div class="grid-block"></div>
</div>
</hljs>

<div class="docs-grid-demo grid-block gutters">
  <div class="shrink grid-block"></div>
  <div class="grid-block"></div>
</div>

<p>Gutters with manual sizing.</p>

<hljs language="html">
<div class="grid-block gutters">
  <div class="small-6 grid-block"></div>
  <div class="small-2 grid-block"></div>
</div>
</hljs>

<div class="docs-grid-demo grid-block gutters">
  <div class="small-6 grid-block"></div>
  <div class="small-2 grid-block"></div>
</div>

<hr>
````