### PR TITLE
Updated gulp-sass in order to build foundation-apps out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-rsync": "^0.0.4",
     "gulp-ruby-sass": "1.0.0-alpha",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.2.0",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "highlight.js": "~7.5.0",

--- a/scss/components/_utilities.scss
+++ b/scss/components/_utilities.scss
@@ -131,15 +131,20 @@ $block-selector: '[class*="grid-block"]';
     .text-#{$align} {
       text-align: $align;
     }
-    
-    @each $size in $breakpoint-classes {
-      @include breakpoint($size) {
+  }
+
+  @each $size in $breakpoint-classes {
+
+    @include breakpoint($size) {
+      @each $align in (left, right, center, justify) {
         .#{$size}-text-#{$align} {
           text-align: $align;
         }
       }
+    }
 
-      @include breakpoint($size only) {
+    @include breakpoint($size only) {
+      @each $align in (left, right, center, justify) {
         .#{$size}-only-text-#{$align} {
           text-align: $align;
         }


### PR DESCRIPTION
The gulp-sass version was 1.3 which had a bug where it didn't find lib-sass dependency
[libsass bindings not found ](https://github.com/dlmanning/gulp-sass/issues/174)
