### PR TITLE
Fixed a bug during fast navigation

### DIFF
--- a/js/angular/services/foundation.dynamicRouting.animations.js
+++ b/js/angular/services/foundation.dynamicRouting.animations.js
@@ -101,7 +101,11 @@
       }
 
       function resetParent() {
-        element.parent().removeClass('position-absolute');
+        var parent = element.parent();
+        if(!parent.length) {
+          return; // this view is already detached from the DOM, can happen in case of hectic clicking around
+        }
+        parent.removeClass('position-absolute');
         if(presetHeight !== true) {
           element.parent()[0].style.height = null;
         }


### PR DESCRIPTION
If you navigate fast though the app, there occasionally happens a race condition, where resetParent tries to access a already detached node. This fixes the issue.