### PR TITLE
Initializing state definitions with empty resolve object so that reso…

### DIFF
--- a/js/angular/services/foundation.dynamicRouting.js
+++ b/js/angular/services/foundation.dynamicRouting.js
@@ -47,6 +47,7 @@
             controller: getController(page),
             data: getData(page),
             animation: buildAnimations(page),
+            resolve: {}
           };
           
           $stateProvider.state(page.name, state);


### PR DESCRIPTION
Initializing state definitions with empty resolve object so that resolves can be added within $stateChangeStart.  This would make it possible to create middleware for states.